### PR TITLE
Enable plug-in agent architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,8 @@ The current JSON file implements the following workflow. However, you can modify
 ## Extending & Contributing
 
 We welcome contributions! Please read [Contributing Guide](CONTRIBUTING.md) for guidelines.
-Please note that this project is released with a [Code of Conduct](CODE_OF_CONDUCT.md). By participating, you agree to follow the terms.
-- **Add New Agents:** Implement new agent classes in `multi_agent_llm_system.py` and add them to the graph in `config.json`.
+-Please note that this project is released with a [Code of Conduct](CODE_OF_CONDUCT.md). By participating, you agree to follow the terms.
+- **Add New Agents:** Implement new agent classes in the `agents` package (files ending with `_agent.py`). They are auto-registered via the plugin system. Add them to the workflow graph in `config.json`.
 - **Customize GUI:** Edit `gui.py` to add new options or workflow controls.
 - **Pull Requests:** Contributions are welcome! Please open an issue or PR for discussion.
 

--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,27 +1,11 @@
+from .registry import AGENT_REGISTRY, register_agent, get_agent_class, load_agents
 from .base_agent import Agent
-from .pdf_loader_agent import PDFLoaderAgent
-from .pdf_summarizer_agent import PDFSummarizerAgent
-from .multi_doc_synthesizer_agent import MultiDocSynthesizerAgent
-from .web_researcher_agent import WebResearcherAgent
-from .experimental_data_loader_agent import ExperimentalDataLoaderAgent
-from .knowledge_integrator_agent import KnowledgeIntegratorAgent
-from .hypothesis_generator_agent import HypothesisGeneratorAgent
-from .experiment_designer_agent import ExperimentDesignerAgent
-# Import the Pydantic models as well if they are intended to be part of the agents public API
 from .sdk_models import WebSearchItem, WebSearchPlan, ReportData
 
-# It might also be good to define __all__ to specify the public API of the package
-__all__ = [
-    "Agent",
-    "PDFLoaderAgent",
-    "PDFSummarizerAgent",
-    "MultiDocSynthesizerAgent",
-    "WebResearcherAgent",
-    "ExperimentalDataLoaderAgent",
-    "KnowledgeIntegratorAgent",
-    "HypothesisGeneratorAgent",
-    "ExperimentDesignerAgent",
-    "WebSearchItem",
-    "WebSearchPlan",
-    "ReportData"
-]
+# Import all modules ending with '_agent' to populate AGENT_REGISTRY
+load_agents(__name__)
+
+# Expose agent classes for backward compatibility
+globals().update(AGENT_REGISTRY)
+
+__all__ = ["Agent", "register_agent", "get_agent_class", "WebSearchItem", "WebSearchPlan", "ReportData"] + list(AGENT_REGISTRY.keys())

--- a/agents/experiment_designer_agent.py
+++ b/agents/experiment_designer_agent.py
@@ -1,7 +1,9 @@
 from typing import Dict, List
 from .base_agent import Agent
+from .registry import register_agent
 from utils import call_openai_api, log_status
 
+@register_agent("ExperimentDesignerAgent")
 class ExperimentDesignerAgent(Agent):
     def execute(self, inputs: dict) -> dict: # Type hint for dict
         current_system_message = self.get_formatted_system_message()

--- a/agents/experimental_data_loader_agent.py
+++ b/agents/experimental_data_loader_agent.py
@@ -1,8 +1,10 @@
 import os
 from typing import Dict
 from .base_agent import Agent
-from utils import call_openai_api, log_status # SCRIPT_DIR is no longer imported from here
+from .registry import register_agent
+from utils import call_openai_api, log_status  # SCRIPT_DIR is no longer imported from here
 
+@register_agent("ExperimentalDataLoaderAgent")
 class ExperimentalDataLoaderAgent(Agent):
     def execute(self, inputs: dict) -> dict: # Type hint for dict
         current_system_message = self.get_formatted_system_message()

--- a/agents/hypothesis_generator_agent.py
+++ b/agents/hypothesis_generator_agent.py
@@ -1,8 +1,10 @@
 import json
 from typing import Dict, List, Any # Any is used for parsed_output
 from .base_agent import Agent
+from .registry import register_agent
 from utils import call_openai_api, log_status
 
+@register_agent("HypothesisGeneratorAgent")
 class HypothesisGeneratorAgent(Agent):
     def execute(self, inputs: dict) -> dict: # Type hint for dict
         num_hypotheses_to_generate = self.config_params.get("num_hypotheses", 3)

--- a/agents/knowledge_integrator_agent.py
+++ b/agents/knowledge_integrator_agent.py
@@ -1,8 +1,10 @@
 from typing import Dict # For type hints
 from .base_agent import Agent
+from .registry import register_agent
 from utils import call_openai_api
 # log_status is available via base_agent.py, or if not, would need to be imported if used directly here
 
+@register_agent("KnowledgeIntegratorAgent")
 class KnowledgeIntegratorAgent(Agent):
     def execute(self, inputs: dict) -> dict: # Type hint for dict
         current_system_message = self.get_formatted_system_message()

--- a/agents/multi_doc_synthesizer_agent.py
+++ b/agents/multi_doc_synthesizer_agent.py
@@ -1,8 +1,10 @@
 import os
 from typing import Dict, List
 from .base_agent import Agent
+from .registry import register_agent
 from utils import call_openai_api, log_status
 
+@register_agent("MultiDocSynthesizerAgent")
 class MultiDocSynthesizerAgent(Agent):
     def execute(self, inputs: dict) -> dict: # Type hint for dict
         current_system_message = self.get_formatted_system_message()

--- a/agents/pdf_loader_agent.py
+++ b/agents/pdf_loader_agent.py
@@ -1,8 +1,10 @@
 import os
 from typing import Dict
 from .base_agent import Agent
-from utils import log_status, PyPDF2 # PyPDF2 needed for PyPDF2.PdfReader
+from .registry import register_agent
+from utils import log_status, PyPDF2  # PyPDF2 needed for PyPDF2.PdfReader
 
+@register_agent("PDFLoaderAgent")
 class PDFLoaderAgent(Agent):
     def execute(self, inputs: dict) -> dict: # Type hint for dict matches common usage
         base_pre_check_result = super().execute(inputs)

--- a/agents/pdf_summarizer_agent.py
+++ b/agents/pdf_summarizer_agent.py
@@ -1,8 +1,10 @@
 import os
 from typing import Dict
 from .base_agent import Agent
+from .registry import register_agent
 from utils import call_openai_api, log_status
 
+@register_agent("PDFSummarizerAgent")
 class PDFSummarizerAgent(Agent):
     def execute(self, inputs: dict) -> dict: # Type hint for dict
         current_system_message = self.get_formatted_system_message()

--- a/agents/registry.py
+++ b/agents/registry.py
@@ -1,0 +1,27 @@
+import os
+import pkgutil
+import importlib
+
+AGENT_REGISTRY = {}
+
+def register_agent(name: str):
+    """Decorator to register an agent class by name."""
+    def decorator(cls):
+        AGENT_REGISTRY[name] = cls
+        return cls
+    return decorator
+
+
+def get_agent_class(name: str):
+    """Retrieve a registered agent class by name."""
+    return AGENT_REGISTRY.get(name)
+
+
+def load_agents(package_name: str = __package__):
+    """Dynamically import modules ending with '_agent' to populate the registry."""
+    package = importlib.import_module(package_name)
+    package_path = package.__path__
+    for _, module_name, _ in pkgutil.iter_modules(package_path):
+        if module_name.endswith('_agent'):
+            importlib.import_module(f"{package_name}.{module_name}")
+

--- a/agents/web_researcher_agent.py
+++ b/agents/web_researcher_agent.py
@@ -2,7 +2,8 @@ import asyncio
 import traceback
 from typing import Dict, Any, Optional, List
 from .base_agent import Agent
-from .sdk_models import WebSearchPlan, ReportData # Moved models
+from .registry import register_agent
+from .sdk_models import WebSearchPlan, ReportData  # Moved models
 # Utilities and SDK components are now imported from utils.py
 from utils import (
     SDK_AVAILABLE, SDSAgent, Runner, WebSearchTool, ModelSettings, # SDK components
@@ -10,6 +11,7 @@ from utils import (
     # set_default_openai_key is handled within utils.load_app_config
 )
 
+@register_agent("WebResearcherAgent")
 class WebResearcherAgent(Agent):
     def execute(self, inputs: dict) -> dict:
         if not SDK_AVAILABLE:

--- a/multi_agent_llm_system.py
+++ b/multi_agent_llm_system.py
@@ -55,17 +55,8 @@ from utils import (
 )
 
 # Imports for refactored Agent classes
-from agents import (
-    Agent, # Base Agent class
-    PDFLoaderAgent,
-    PDFSummarizerAgent,
-    MultiDocSynthesizerAgent,
-    WebResearcherAgent,
-    ExperimentalDataLoaderAgent,
-    KnowledgeIntegratorAgent,
-    HypothesisGeneratorAgent,
-    ExperimentDesignerAgent
-)
+# Core agent utilities
+from agents import Agent, get_agent_class
 # SDK Models are now in agents.sdk_models; WebResearcherAgent imports them directly.
 
 
@@ -130,18 +121,11 @@ class GraphOrchestrator:
         log_status(f"[GraphOrchestrator] INFO: Node execution order determined: {self.node_order}")
 
     def _initialize_agents(self):
-        agent_class_map = {
-            "PDFLoaderAgent": PDFLoaderAgent, "PDFSummarizerAgent": PDFSummarizerAgent,
-            "MultiDocSynthesizerAgent": MultiDocSynthesizerAgent, "WebResearcherAgent": WebResearcherAgent,
-            "ExperimentalDataLoaderAgent": ExperimentalDataLoaderAgent,
-            "KnowledgeIntegratorAgent": KnowledgeIntegratorAgent,
-            "HypothesisGeneratorAgent": HypothesisGeneratorAgent, "ExperimentDesignerAgent": ExperimentDesignerAgent,
-        }
         for node_def in self.graph_definition.get('nodes', []):
             agent_id = node_def['id']
             agent_type_name = node_def['type']
             agent_config_params = node_def.get('config', {})
-            agent_class = agent_class_map.get(agent_type_name)
+            agent_class = get_agent_class(agent_type_name)
             if not agent_class:
                 log_status(f"[GraphOrchestrator] ERROR: Unknown agent type: {agent_type_name} for node {agent_id}")
                 raise ValueError(f"Unknown agent type: {agent_type_name} for node {agent_id}")


### PR DESCRIPTION
## Summary
- create `agents/registry.py` for dynamic agent registration
- auto-load agent modules via `agents/__init__.py`
- decorate each agent class with `register_agent`
- lookup agent types from registry in `GraphOrchestrator`
- document plugin approach in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6850b8ae1dd48331a41bf08193f416d5