### PR TITLE
Ensure agents require injected LLM client

### DIFF
--- a/agents/base_agent.py
+++ b/agents/base_agent.py
@@ -9,6 +9,8 @@ class Agent:
         self.agent_id = agent_id
         self.agent_type = agent_type
         self.config_params = config_params if config_params else {}
+        if llm is None:
+            raise ValueError("LLMClient instance must be provided to Agent")
         self.llm = llm
         model_key_from_config = self.config_params.get("model_key")
         self.model_name = get_model_name(model_key_from_config)

--- a/llm_openai.py
+++ b/llm_openai.py
@@ -2,7 +2,7 @@ from typing import Optional, Dict
 import os
 import json
 from llm import LLMClient
-from utils import log_status, get_model_name, APP_CONFIG
+from utils import log_status, get_model_name
 
 try:
     from openai import OpenAI as OpenAIClient, APIConnectionError, APITimeoutError, RateLimitError, AuthenticationError, BadRequestError


### PR DESCRIPTION
## Summary
- enforce providing an LLMClient when initializing agents
- clean up OpenAI client imports

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a858fa7204833197ade72d371949c5