### PR TITLE
Externalize agent limits and temperature settings

### DIFF
--- a/agents/experimental_data_loader_agent.py
+++ b/agents/experimental_data_loader_agent.py
@@ -36,18 +36,23 @@ class ExperimentalDataLoaderAgent(Agent):
 
             # Decide whether to use LLM for summarization or pass raw content
             if current_system_message and not current_system_message.startswith("ERROR:") and self.config_params.get("use_llm_to_summarize_data", False): # Example: Add a config flag
-                max_exp_data_len = 10000 # Consider making this configurable
+                max_exp_data_len = self.config_params.get("max_exp_data_len", 10000)
                 truncated_data_content = data_content
                 if len(data_content) > max_exp_data_len:
                     log_status(
                         f"[{self.agent_id}] INFO: Truncating experimental data from {len(data_content)} to {max_exp_data_len} for LLM processing.")
                     truncated_data_content = data_content[:max_exp_data_len]
 
-                prompt = f"Please process and summarize the following experimental data content from file '{os.path.basename(resolved_data_path)}':\n\n---\n{truncated_data_content}\n---"
+                prompt = (
+                    f"Please process and summarize the following experimental data content from file '"
+                    f"{os.path.basename(resolved_data_path)}':\n\n---\n{truncated_data_content}\n---"
+                )
+                temperature = float(self.config_params.get("temperature", 0.6))
                 summary = self.llm.complete(
                     system=current_system_message,
                     prompt=prompt,
                     model=self.model_name,
+                    temperature=temperature,
                 )
 
                 if summary.startswith("Error:"):

--- a/agents/hypothesis_generator_agent.py
+++ b/agents/hypothesis_generator_agent.py
@@ -32,7 +32,7 @@ class HypothesisGeneratorAgent(Agent):
             log_status(f"[{self.agent_id}] INPUT_ERROR: {error_msg}")
             return {"hypotheses_output_blob": "", "hypotheses_list": [], "key_opportunities": "", "error": error_msg}
 
-        max_brief_len = 15000 # Consider making this configurable
+        max_brief_len = self.config_params.get("max_brief_len", 15000)
         if len(integrated_knowledge_brief) > max_brief_len:
             log_status(
                 f"[{self.agent_id}] INFO: Truncating integrated_knowledge_brief from {len(integrated_knowledge_brief)} to {max_brief_len} for hypothesis generation.")
@@ -44,10 +44,12 @@ class HypothesisGeneratorAgent(Agent):
             "strictly in the specified JSON format."
         )
         log_status(f"[{self.agent_id}] Requesting {num_hypotheses_to_generate} hypotheses from LLM.")
+        temperature = float(self.config_params.get("temperature", 0.6))
         llm_response_str = self.llm.complete(
             system=current_system_message,
             prompt=user_prompt,
             model=self.model_name,
+            temperature=temperature,
         )
 
         if llm_response_str.startswith("Error:"):

--- a/agents/knowledge_integrator_agent.py
+++ b/agents/knowledge_integrator_agent.py
@@ -30,7 +30,7 @@ class KnowledgeIntegratorAgent(Agent):
             experimental_data_summary = f"[Error in upstream experimental data loading: {experimental_data_summary if isinstance(experimental_data_summary, str) else 'Content unavailable'}]"
 
         # Truncate inputs if they are too long
-        max_input_segment_len = 10000 # Consider making this configurable
+        max_input_segment_len = self.config_params.get("max_input_segment_len", 10000)
         if len(multi_doc_synthesis) > max_input_segment_len:
             multi_doc_synthesis = multi_doc_synthesis[:max_input_segment_len] + "\n[...truncated due to length...]"
         if len(web_research_summary) > max_input_segment_len:
@@ -49,11 +49,12 @@ class KnowledgeIntegratorAgent(Agent):
             f"Provide the integrated knowledge brief based on these sources, adhering to the specific analytical points outlined in your primary instructions (synergies, conflicts, gaps, contradictions, unanswered questions, novel links, limitations)."
         )
 
+        temperature = float(self.config_params.get("temperature", 0.6))
         integrated_brief = self.llm.complete(
             system=current_system_message,
             prompt=prompt,
             model=self.model_name,
-            temperature=0.6,
+            temperature=temperature,
         )
 
         if integrated_brief.startswith("Error:"):

--- a/agents/multi_doc_synthesizer_agent.py
+++ b/agents/multi_doc_synthesizer_agent.py
@@ -31,18 +31,23 @@ class MultiDocSynthesizerAgent(Agent):
             formatted_summaries.append(f"Summary from '{pdf_name}':\n{item['summary']}\n---")
 
         combined_summaries_text = "\n\n".join(formatted_summaries)
-        max_combined_len = 30000 # Consider making this configurable
+        max_combined_len = self.config_params.get("max_combined_len", 30000)
         if len(combined_summaries_text) > max_combined_len:
             log_status(
                 f"[{self.agent_id}] INFO: Truncating combined summaries from {len(combined_summaries_text)} to {max_combined_len} chars for synthesis.")
             combined_summaries_text = combined_summaries_text[:max_combined_len]
 
-        prompt = f"Synthesize the following collection of summaries from multiple academic documents:\n\n{combined_summaries_text}\n\nProvide a coherent 'cross-document understanding' as per your role description."
+        temperature = float(self.config_params.get("temperature", 0.6))
+        prompt = (
+            "Synthesize the following collection of summaries from multiple academic documents:\n\n"
+            f"{combined_summaries_text}\n\n"
+            "Provide a coherent 'cross-document understanding' as per your role description."
+        )
         synthesis_output = self.llm.complete(
             system=current_system_message,
             prompt=prompt,
             model=self.model_name,
-            temperature=0.6,
+            temperature=temperature,
         )
         if synthesis_output.startswith("Error:"):
             return {"multi_doc_synthesis_output": "", "error": synthesis_output}

--- a/agents/pdf_summarizer_agent.py
+++ b/agents/pdf_summarizer_agent.py
@@ -22,12 +22,17 @@ class PDFSummarizerAgent(Agent):
             log_status(
                 f"[{self.agent_id}] INFO: Truncating PDF text from {len(pdf_text_content)} to {max_len} chars for summarization.")
             pdf_text_content = pdf_text_content[:max_len]
-        prompt = f"Please summarize the following academic text from document '{os.path.basename(original_pdf_path)}':\n\n---\n{pdf_text_content}\n---"
+
+        temperature = float(self.config_params.get("temperature", 0.6))
+        prompt = (
+            f"Please summarize the following academic text from document '"
+            f"{os.path.basename(original_pdf_path)}':\n\n---\n{pdf_text_content}\n---"
+        )
         summary = self.llm.complete(
             system=current_system_message,
             prompt=prompt,
             model=self.model_name,
-            temperature=0.6,
+            temperature=temperature,
         )
         if summary.startswith("Error:"):
             return {"summary": "", "error": summary, "original_pdf_path": original_pdf_path}

--- a/config.json
+++ b/config.json
@@ -44,7 +44,9 @@
         "config": {
           "description": "Summarizes text from a single PDF. Invoked multiple times.",
           "model_key": "pdf_summarizer",
-          "system_message_key": "pdf_summarizer_sm"
+          "system_message_key": "pdf_summarizer_sm",
+          "max_input_length": 15000,
+          "temperature": 0.6
         }
       },
       {
@@ -53,7 +55,9 @@
         "config": {
           "description": "Synthesizes summaries from ALL processed PDFs into a single understanding.",
           "model_key": "multi_doc_synthesizer_model",
-          "system_message_key": "multi_doc_synthesizer_sm"
+          "system_message_key": "multi_doc_synthesizer_sm",
+          "max_combined_len": 30000,
+          "temperature": 0.6
         }
       },
       {
@@ -70,7 +74,10 @@
         "type": "ExperimentalDataLoaderAgent",
         "config": {
           "description": "Loads and structures textual summary of experimental data from a file.",
-          "system_message_key": "experimental_data_loader_sm"
+          "system_message_key": "experimental_data_loader_sm",
+          "use_llm_to_summarize_data": false,
+          "max_exp_data_len": 10000,
+          "temperature": 0.6
         }
       },
       {
@@ -79,7 +86,9 @@
         "config": {
           "description": "Integrates multi-doc synthesis, web research, and experimental data into a final brief.",
           "model_key": "knowledge_integrator_model",
-          "system_message_key": "knowledge_integrator_sm"
+          "system_message_key": "knowledge_integrator_sm",
+          "max_input_segment_len": 10000,
+          "temperature": 0.6
         }
       },
       {
@@ -89,7 +98,9 @@
           "description": "Generates novel hypotheses from the integrated knowledge brief.",
           "model_key": "hypothesis_generator",
           "system_message_key": "hypothesis_generator_sm",
-          "num_hypotheses": 5
+          "num_hypotheses": 5,
+          "max_brief_len": 15000,
+          "temperature": 0.6
         }
       },
       {


### PR DESCRIPTION
## Summary
- make summarizer, synthesizer, knowledge integrator, hypothesis generator, and experimental data loader truncation and temperature settings configurable
- add corresponding parameters in `config.json`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a896a80bc0833191c1089b0690d8b9