### PR TITLE
Fix call_openai_api missing app configuration

### DIFF
--- a/tests/test_call_openai_api.py
+++ b/tests/test_call_openai_api.py
@@ -1,0 +1,47 @@
+import llm_openai
+from utils import call_openai_api, APP_CONFIG
+
+
+def test_call_openai_api_passes_app_config(monkeypatch):
+    # Prepare application configuration
+    APP_CONFIG.clear()
+    APP_CONFIG.update({
+        "system_variables": {
+            "openai_api_key": "test-key",
+            "openai_api_timeout_seconds": 10,
+        }
+    })
+
+    captured = {}
+
+    class DummyLLM:
+        def __init__(self, app_config, api_key=None, timeout=0):
+            captured["app_config"] = app_config
+            captured["api_key"] = api_key
+            captured["timeout"] = timeout
+
+        def complete(self, system, prompt, model=None, temperature=None):
+            captured["system"] = system
+            captured["prompt"] = prompt
+            captured["model"] = model
+            captured["temperature"] = temperature
+            return "dummy-response"
+
+    # Patch OpenAILLM to our dummy implementation
+    monkeypatch.setattr(llm_openai, "OpenAILLM", DummyLLM)
+
+    result = call_openai_api(
+        prompt="hello",
+        system_message="system-msg",
+        model_name="test-model",
+        temperature=0.3,
+    )
+
+    assert result == "dummy-response"
+    assert captured["app_config"] is APP_CONFIG
+    assert captured["api_key"] == "test-key"
+    assert captured["timeout"] == 10
+    assert captured["system"] == "system-msg"
+    assert captured["prompt"] == "hello"
+    assert captured["model"] == "test-model"
+    assert captured["temperature"] == 0.3

--- a/utils.py
+++ b/utils.py
@@ -123,7 +123,18 @@ def call_openai_api(prompt: str, system_message: str = "You are a helpful assist
         return "Error: OpenAI library is not available."
 
     api_key = APP_CONFIG.get("system_variables", {}).get("openai_api_key")
-    timeout = float(APP_CONFIG.get("system_variables", {}).get("openai_api_timeout_seconds", 120))
-    llm = OpenAILLM(api_key=api_key, timeout=int(timeout))
-    return llm.complete(system=system_message, prompt=prompt,
-                        model=model_name, temperature=temperature)
+    timeout = float(
+        APP_CONFIG.get("system_variables", {}).get("openai_api_timeout_seconds", 120)
+    )
+    # BUGFIX: OpenAILLM requires the application configuration during
+    # initialisation.  The previous implementation omitted this argument,
+    # resulting in a ``TypeError`` being raised when ``call_openai_api`` was
+    # invoked.  We now pass the global ``APP_CONFIG`` so the wrapper behaves
+    # as intended.
+    llm = OpenAILLM(app_config=APP_CONFIG, api_key=api_key, timeout=int(timeout))
+    return llm.complete(
+        system=system_message,
+        prompt=prompt,
+        model=model_name,
+        temperature=temperature,
+    )


### PR DESCRIPTION
## Summary
- Pass the global application configuration to `OpenAILLM` when using `call_openai_api`
- Add regression test ensuring the wrapper forwards configuration and parameters correctly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac788f6b988331a2ff51c7f251a641