### PR TITLE
Ensure base Agent execute is overridden

### DIFF
--- a/agents/base_agent.py
+++ b/agents/base_agent.py
@@ -45,4 +45,4 @@ class Agent:
         if self.system_message.startswith("ERROR:"):
             return {
                 "error": f"Agent {self.agent_id} cannot execute due to configuration error for system message (key: '{self.config_params.get('system_message_key')}'): {self.system_message}"}
-        return None
+        raise NotImplementedError("Subclasses must implement execute()")


### PR DESCRIPTION
## Summary
- Make `Agent.execute` raise `NotImplementedError` instead of returning `None` when not overridden

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac7c587370833185eabc6bf59c98b0