### PR TITLE
Automatically load application config into global state

### DIFF
--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -6,6 +6,7 @@ from reportlab.pdfgen import canvas
 from reportlab.lib.pagesizes import letter
 
 from multi_agent_llm_system import GraphOrchestrator, load_app_config
+from utils import APP_CONFIG
 from llm_fake import FakeLLM
 from agents.base_agent import Agent
 from agents.registry import register_agent
@@ -33,11 +34,13 @@ class TestGraphOrchestrator(unittest.TestCase):
         os.makedirs(self.test_outputs_dir, exist_ok=True)
         # The new agents require a dummy API key to be set, even for tests.
         os.environ["OPENAI_API_KEY"] = "dummy"
+        APP_CONFIG.clear()
 
     def tearDown(self):
         if os.path.exists(self.test_outputs_dir):
             shutil.rmtree(self.test_outputs_dir)
         del os.environ["OPENAI_API_KEY"]
+        APP_CONFIG.clear()
 
     def test_topological_sort(self):
         config = {
@@ -78,6 +81,7 @@ class TestGraphOrchestrator(unittest.TestCase):
 
         # Load the actual application config
         app_config = load_app_config()
+        self.assertEqual(APP_CONFIG, app_config)
         # Use a fake LLM for testing
         llm = FakeLLM(app_config)
 

--- a/utils.py
+++ b/utils.py
@@ -54,10 +54,12 @@ def load_app_config(config_path="config.json", main_script_dir=None):
     Loads the application configuration from a JSON file.
     Dynamically imports PyPDF2 and reportlab if available.
     Uses main_script_dir to resolve relative config_path if provided,
-    otherwise assumes config_path is absolute or relative to where load_app_config is called.
+    otherwise assumes config_path is absolute or relative to where
+    load_app_config is called. The loaded configuration is stored in the
+    module-level ``APP_CONFIG`` dictionary, mutating global state.
     Returns the config dictionary on success, None on failure.
     """
-    global openai_errors, OPENAI_SDK_AVAILABLE
+    global openai_errors, OPENAI_SDK_AVAILABLE, APP_CONFIG
 
     if main_script_dir and not os.path.isabs(config_path):
         resolved_config_path = os.path.join(main_script_dir, config_path)
@@ -72,6 +74,12 @@ def load_app_config(config_path="config.json", main_script_dir=None):
 
         # The dynamic loading of reportlab has been removed from this central utility.
         # Client code that needs reportlab should handle its own imports and availability checks.
+
+        # Store the loaded configuration in the module-level APP_CONFIG so
+        # subsequent calls can rely on the global state without manually
+        # updating it.
+        APP_CONFIG.clear()
+        APP_CONFIG.update(config)
 
         return config
     except FileNotFoundError:


### PR DESCRIPTION
## Summary
- Update `load_app_config` to populate the global `APP_CONFIG` and document the side effect.
- Ensure orchestrator tests reset global config and verify it is set when loading.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac7c6f07188331bee60b26668444aa