### PR TITLE
Add Pydantic schema validation for graph configs

### DIFF
--- a/config_schema.py
+++ b/config_schema.py
@@ -1,0 +1,37 @@
+from typing import Any, Dict, List
+from pydantic import BaseModel, Field, model_validator, ConfigDict
+
+
+class NodeDefinition(BaseModel):
+    id: str
+    type: str
+    config: Dict[str, Any] = Field(default_factory=dict)
+
+
+class EdgeDefinition(BaseModel):
+    from_node: str = Field(..., alias="from")
+    to_node: str = Field(..., alias="to")
+    data_mapping: Dict[str, str] = Field(default_factory=dict)
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class GraphDefinition(BaseModel):
+    nodes: List[NodeDefinition]
+    edges: List[EdgeDefinition]
+
+    @model_validator(mode="after")
+    def check_edges_reference_known_nodes(self):
+        node_ids = {node.id for node in self.nodes}
+        for edge in self.edges:
+            if edge.from_node not in node_ids or edge.to_node not in node_ids:
+                raise ValueError(
+                    f"Edge references undefined node id: {edge.from_node} -> {edge.to_node}"
+                )
+        return self
+
+
+def validate_graph_definition(graph_def: Dict[str, Any]) -> Dict[str, Any]:
+    """Validate and normalize a graph definition dictionary."""
+    graph = GraphDefinition.model_validate(graph_def)
+    return graph.model_dump(by_alias=True)

--- a/multi_agent_llm_system.py
+++ b/multi_agent_llm_system.py
@@ -14,6 +14,9 @@ from utils import (
     set_status_callback,
 )
 
+# Configuration schema validation
+from config_schema import validate_graph_definition
+
 # Imports for refactored Agent classes
 # Core agent utilities
 from agents import Agent, get_agent_class
@@ -31,7 +34,8 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 
 class GraphOrchestrator:
     def __init__(self, graph_definition_from_config, llm: LLMClient, app_config: Dict[str, Any]):
-        self.graph_definition = graph_definition_from_config
+        # Validate and normalize the graph definition before proceeding
+        self.graph_definition = validate_graph_definition(graph_definition_from_config)
         self.app_config = app_config
         self.agents = {}
         self.adjacency_list = defaultdict(list)

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ requests
 PyPDF2
 reportlab
 PyQt6
+pydantic

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -1,0 +1,40 @@
+import os
+import unittest
+
+from pydantic import ValidationError
+
+from multi_agent_llm_system import GraphOrchestrator
+from llm_fake import FakeLLM
+
+
+class TestConfigSchema(unittest.TestCase):
+    def setUp(self):
+        os.environ["OPENAI_API_KEY"] = "dummy"
+
+    def tearDown(self):
+        del os.environ["OPENAI_API_KEY"]
+
+    def test_missing_node_type_raises(self):
+        invalid_graph = {
+            "nodes": [{"id": "a"}],
+            "edges": []
+        }
+        with self.assertRaises(ValidationError):
+            GraphOrchestrator(invalid_graph, FakeLLM(), {})
+
+    def test_invalid_data_mapping_type(self):
+        invalid_graph = {
+            "nodes": [
+                {"id": "a", "type": "A"},
+                {"id": "b", "type": "B"},
+            ],
+            "edges": [
+                {"from": "a", "to": "b", "data_mapping": ["not", "a", "dict"]}
+            ]
+        }
+        with self.assertRaises(ValidationError):
+            GraphOrchestrator(invalid_graph, FakeLLM(), {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils.py
+++ b/utils.py
@@ -2,6 +2,10 @@ import os
 import json
 from typing import Optional
 
+from pydantic import ValidationError
+
+from config_schema import validate_graph_definition
+
 # Attempt to import OpenAI library and its specific errors.
 # These are primarily used by call_openai_api.
 try:
@@ -72,6 +76,10 @@ def load_app_config(config_path="config.json", main_script_dir=None):
             config = json.load(f)
         log_status(f"[AppConfig] Successfully loaded configuration from '{resolved_config_path}'.")
 
+        # Validate graph configuration if present
+        if config.get("graph_definition"):
+            validate_graph_definition(config["graph_definition"])
+
         # The dynamic loading of reportlab has been removed from this central utility.
         # Client code that needs reportlab should handle its own imports and availability checks.
 
@@ -86,6 +94,8 @@ def load_app_config(config_path="config.json", main_script_dir=None):
         log_status(f"[AppConfig] ERROR: Configuration file '{resolved_config_path}' not found.")
     except json.JSONDecodeError as e:
         log_status(f"[AppConfig] ERROR: Could not decode JSON from '{resolved_config_path}': {e}.")
+    except ValidationError as e:
+        log_status(f"[AppConfig] ERROR: Graph configuration validation failed: {e}")
     except Exception as e:
         log_status(f"[AppConfig] ERROR: An unexpected error occurred while loading config '{resolved_config_path}': {e}.")
     return None


### PR DESCRIPTION
## Summary
- add Pydantic models to validate nodes, edges and data mappings
- validate graph definitions when loading config and starting the orchestrator
- cover schema validation with new unit tests and document pydantic dependency

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac832e34088331b6c4168b14e8b35d