### PR TITLE
Enable parallel PDF summarization

### DIFF
--- a/config.json
+++ b/config.json
@@ -54,7 +54,8 @@
           "model_key": "pdf_summarizer",
           "system_message_key": "pdf_summarizer_sm",
           "max_input_length": 15000,
-          "temperature": 0.6
+          "temperature": 0.6,
+          "parallel_execution": true
         }
       },
       {

--- a/config_cli_test_integrated.json
+++ b/config_cli_test_integrated.json
@@ -48,7 +48,8 @@
         "config": {
           "loop_over": "loader_results",
           "model_key": "pdf_summarizer",
-          "system_message_key": "pdf_summarizer_sm"
+          "system_message_key": "pdf_summarizer_sm",
+          "parallel_execution": true
         }
       },
       {


### PR DESCRIPTION
## Summary
- Add optional parallel execution to `GraphOrchestrator` loops using `ThreadPoolExecutor`
- Allow PDF summarization to run concurrently by enabling `parallel_execution` in config files
- Cover parallel execution with new unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac84884028833183fe5714bfc0a54b