### PR TITLE
refactor: use structured LLM errors

### DIFF
--- a/agents/multi_doc_synthesizer_agent.py
+++ b/agents/multi_doc_synthesizer_agent.py
@@ -2,6 +2,7 @@ import os
 from .base_agent import Agent
 from .registry import register_agent
 from utils import log_status
+from llm import LLMError
 
 @register_agent("MultiDocSynthesizerAgent")
 class MultiDocSynthesizerAgent(Agent):
@@ -43,12 +44,13 @@ class MultiDocSynthesizerAgent(Agent):
             f"{combined_summaries_text}\n\n"
             "Provide a coherent 'cross-document understanding' as per your role description."
         )
-        synthesis_output = self.llm.complete(
-            system=current_system_message,
-            prompt=prompt,
-            model=self.model_name,
-            temperature=temperature,
-        )
-        if synthesis_output.startswith("Error:"):
-            return {"multi_doc_synthesis_output": "", "error": synthesis_output}
+        try:
+            synthesis_output = self.llm.complete(
+                system=current_system_message,
+                prompt=prompt,
+                model=self.model_name,
+                temperature=temperature,
+            )
+        except LLMError as e:
+            return {"multi_doc_synthesis_output": "", "error": str(e)}
         return {"multi_doc_synthesis_output": synthesis_output}

--- a/llm.py
+++ b/llm.py
@@ -1,11 +1,21 @@
 from typing import Protocol, Optional, Dict, Any
 
+
+class LLMError(Exception):
+    """Represents a failure during an LLM completion call."""
+
+
 class LLMClient(Protocol):
     def __init__(self, app_config: Dict[str, Any], api_key: Optional[str] = None, timeout: int = 120):
         ...
 
-    def complete(self, *, system: str, prompt: str,
-                 model: Optional[str] = None,
-                 temperature: Optional[float] = None,
-                 extra: Optional[Dict] = None) -> str:
+    def complete(
+        self,
+        *,
+        system: str,
+        prompt: str,
+        model: Optional[str] = None,
+        temperature: Optional[float] = None,
+        extra: Optional[Dict] = None,
+    ) -> str:
         ...

--- a/utils.py
+++ b/utils.py
@@ -131,14 +131,21 @@ def get_prompt_text(app_config: dict, prompt_key: Optional[str]) -> str:
     return prompt_text
 
 
-def call_openai_api(prompt: str, system_message: str = "You are a helpful assistant.",
-                    agent_name: str = "LLM", model_name: Optional[str] = None,
-                    temperature: float = 0.5) -> str:
+from llm import LLMError
+
+
+def call_openai_api(
+    prompt: str,
+    system_message: str = "You are a helpful assistant.",
+    agent_name: str = "LLM",
+    model_name: Optional[str] = None,
+    temperature: float = 0.5,
+) -> str:
     """Deprecated wrapper around OpenAILLM for backward compatibility."""
     try:
         from llm_openai import OpenAILLM
-    except ImportError:
-        return "Error: OpenAI library is not available."
+    except ImportError as e:
+        raise LLMError("OpenAI library is not available.") from e
 
     api_key = APP_CONFIG.get("system_variables", {}).get("openai_api_key")
     timeout = float(


### PR DESCRIPTION
## Summary
- add `LLMError` exception and raise it from the OpenAI client
- propagate errors via flags in the graph orchestrator instead of sentinel strings
- update agents and utilities to catch `LLMError` and return structured error results

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac8596dba4833185ec0398709aea25