### PR TITLE
test: add coverage for integrator and experiment designer

### DIFF
--- a/tests/test_agent_integration.py
+++ b/tests/test_agent_integration.py
@@ -1,0 +1,64 @@
+import os
+import unittest
+
+from agents.knowledge_integrator_agent import KnowledgeIntegratorAgent
+from agents.hypothesis_generator_agent import HypothesisGeneratorAgent
+from agents.experiment_designer_agent import ExperimentDesignerAgent
+from llm_fake import FakeLLM
+
+
+class TestAgentIntegration(unittest.TestCase):
+    def setUp(self):
+        os.environ["OPENAI_API_KEY"] = "dummy_key"
+        self.app_config = {
+            "system_variables": {"models": {}},
+            "agent_prompts": {"hypothesis_generator_sm": "prompt"},
+        }
+        self.llm = FakeLLM(self.app_config)
+        self.knowledge_agent = KnowledgeIntegratorAgent(
+            "kia",
+            "KnowledgeIntegratorAgent",
+            {},
+            self.llm,
+            self.app_config,
+        )
+        self.hypothesis_agent = HypothesisGeneratorAgent(
+            "hga",
+            "HypothesisGeneratorAgent",
+            {"num_hypotheses": 1},
+            self.llm,
+            self.app_config,
+        )
+        self.experiment_agent = ExperimentDesignerAgent(
+            "eda",
+            "ExperimentDesignerAgent",
+            {},
+            self.llm,
+            self.app_config,
+        )
+
+    def tearDown(self):
+        del os.environ["OPENAI_API_KEY"]
+
+    def test_pipeline(self):
+        knowledge_out = self.knowledge_agent.execute(
+            {
+                "multi_doc_synthesis": "docs",
+                "web_research_summary": "web",
+                "experimental_data_summary": "data",
+            }
+        )
+        self.assertIn("integrated_knowledge_brief", knowledge_out)
+
+        hypo_out = self.hypothesis_agent.execute(knowledge_out)
+        self.assertIn("hypotheses_list", hypo_out)
+        self.assertEqual(len(hypo_out["hypotheses_list"]), 1)
+
+        exp_out = self.experiment_agent.execute(hypo_out)
+        designs = exp_out["experiment_designs_list"]
+        self.assertEqual(len(designs), 1)
+        self.assertEqual(designs[0]["experiment_design"], "[FAKE] ok")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_experiment_designer_agent.py
+++ b/tests/test_experiment_designer_agent.py
@@ -1,0 +1,44 @@
+import os
+import unittest
+
+from agents.experiment_designer_agent import ExperimentDesignerAgent
+from llm_fake import FakeLLM
+
+
+class TestExperimentDesignerAgent(unittest.TestCase):
+    def setUp(self):
+        os.environ["OPENAI_API_KEY"] = "dummy_key"
+        app_config = {"system_variables": {"models": {}}, "agent_prompts": {}}
+        self.agent = ExperimentDesignerAgent(
+            "eda",
+            "ExperimentDesignerAgent",
+            {},
+            FakeLLM(app_config),
+            app_config,
+        )
+
+    def tearDown(self):
+        del os.environ["OPENAI_API_KEY"]
+
+    def test_designs_experiment(self):
+        hypotheses = [{"hypothesis": "A", "justification": "Because"}]
+        result = self.agent.execute({"hypotheses_list": hypotheses})
+        designs = result["experiment_designs_list"]
+        self.assertEqual(len(designs), 1)
+        self.assertEqual(designs[0]["experiment_design"], "[FAKE] ok")
+        self.assertNotIn("error", designs[0])
+
+    def test_handles_upstream_error_flag(self):
+        result = self.agent.execute({"hypotheses_list_error": True})
+        self.assertEqual(result["experiment_designs_list"], [])
+        self.assertIn("error", result)
+
+    def test_invalid_hypothesis_object(self):
+        result = self.agent.execute({"hypotheses_list": ["bad"]})
+        designs = result["experiment_designs_list"]
+        self.assertEqual(designs[0]["experiment_design"], "")
+        self.assertIn("error", designs[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_knowledge_integrator_agent.py
+++ b/tests/test_knowledge_integrator_agent.py
@@ -1,0 +1,48 @@
+import os
+import unittest
+
+from agents.knowledge_integrator_agent import KnowledgeIntegratorAgent
+from llm_fake import FakeLLM
+
+
+class TestKnowledgeIntegratorAgent(unittest.TestCase):
+    def setUp(self):
+        os.environ["OPENAI_API_KEY"] = "dummy_key"
+        app_config = {"system_variables": {"models": {}}, "agent_prompts": {}}
+        self.agent = KnowledgeIntegratorAgent(
+            "kia",
+            "KnowledgeIntegratorAgent",
+            {},
+            FakeLLM(app_config),
+            app_config,
+        )
+
+    def tearDown(self):
+        del os.environ["OPENAI_API_KEY"]
+
+    def test_integrates_sources(self):
+        inputs = {
+            "multi_doc_synthesis": "docs",
+            "web_research_summary": "web",
+            "experimental_data_summary": "data",
+        }
+        result = self.agent.execute(inputs)
+        self.assertIn("integrated_knowledge_brief", result)
+        self.assertEqual(result["integrated_knowledge_brief"], "[FAKE] ok")
+        self.assertNotIn("error", result)
+
+    def test_handles_upstream_errors(self):
+        inputs = {
+            "multi_doc_synthesis_error": True,
+            "web_research_summary_error": True,
+            "experimental_data_summary_error": True,
+            "error": "fail",
+        }
+        result = self.agent.execute(inputs)
+        self.assertIn("integrated_knowledge_brief", result)
+        self.assertEqual(result["integrated_knowledge_brief"], "[FAKE] ok")
+        self.assertNotIn("error", result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add unit tests for `KnowledgeIntegratorAgent`
- add unit tests for `ExperimentDesignerAgent`
- add cross-agent pipeline test covering knowledge integration, hypothesis generation, and experiment design

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ac8af7665c8331857abc771b9e5f27