### PR TITLE
Add agent graph visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 - Experimental Planning: Generates hypotheses and designs experiments automatically.
 - User-Friendly GUI: Easily configure and launch workflows with real-time monitoring.
 - Customizable Workflows: Adjust agent prompts, models, and workflow topology via config.json.
+- Graph Visualization: Export the agent workflow graph to aid debugging and understanding.
 - Extensible Architecture: Add new agents for specialized tasks.
 
 ## Table of Contents
@@ -61,7 +62,7 @@
     - `HypothesisGeneratorAgent`: Generates research hypotheses.
     - `ExperimentDesignerAgent`: Designs experiments for generated hypotheses.
     - `ObserverAgent`: Reviews outputs from all agents and reports any detected errors.
-  - **Graph Orchestrator:** Executes the workflow graph as defined in `config.json`, ensuring correct data flow and error handling.
+  - **Graph Orchestrator:** Executes the workflow graph as defined in `config.json`, ensuring correct data flow and error handling. It can also export the graph structure for visualization via Graphviz.
   - **Output Handling:** Saves synthesized outputs, hypotheses, and experiment designs into organized subfolders.
 - **Usage:** Can be called from the GUI or invoked directly for CLI testing.
 

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -81,6 +81,25 @@ class TestGraphOrchestrator(unittest.TestCase):
         self.assertEqual(outputs_history["b"], {"out2": "output from B"})
         self.assertEqual(outputs_history["c"], {"out3": "output from C"})
 
+    def test_visualize_graph(self):
+        config = {
+            "graph_definition": {
+                "nodes": [
+                    {"id": "a", "type": "A"},
+                    {"id": "b", "type": "B"},
+                ],
+                "edges": [
+                    {"from": "a", "to": "b"},
+                ],
+            }
+        }
+        llm = FakeLLM()
+        app_config = {"system_variables": {"default_llm_model": "test_model"}}
+        orchestrator = GraphOrchestrator(config["graph_definition"], llm, app_config)
+        output_base = os.path.join(self.test_outputs_dir, "graph")
+        path = orchestrator.visualize(output_base)
+        self.assertTrue(os.path.exists(path))
+
 
     @patch('os.path.exists')
     @patch('agents.deep_research_summarizer_agent.FAISS')


### PR DESCRIPTION
## Summary
- add `visualize` method to `GraphOrchestrator` for exporting agent graphs and DOT files
- document graph visualization feature in README
- test graph visualization to ensure output is generated

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac8d60e4fc8331b00315d6507d73c3