### PR TITLE
Add adaptive graph runner script

### DIFF
--- a/adaptive/adaptive_graph_runner.py
+++ b/adaptive/adaptive_graph_runner.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import argparse
+import importlib
+from typing import Any, Callable, Dict, Optional
+
+from multi_agent_llm_system import GraphOrchestrator
+
+from .evaluation import evaluate_target_function
+from .json_utils import load_json, save_json
+
+
+def _create_llm_client(app_config: Dict[str, Any]):
+    """Initialize the LLM client based on configuration."""
+    system_vars = app_config.get("system_variables", {})
+    llm_client_type = system_vars.get("llm_client", "openai")
+    api_key = system_vars.get("openai_api_key")
+    timeout = float(system_vars.get("openai_api_timeout_seconds", 120))
+
+    if llm_client_type == "openai" and api_key and "YOUR" not in api_key:
+        from llm_openai import OpenAILLM
+
+        return OpenAILLM(app_config=app_config, api_key=api_key, timeout=int(timeout))
+    else:
+        from llm_fake import FakeLLM
+
+        return FakeLLM(app_config=app_config)
+
+
+def adaptive_cycle(
+    config_path: str,
+    inputs: Dict[str, Any],
+    evaluate: Callable[[Dict[str, Any], Dict[str, Any], float, int], Optional[Dict[str, Any]]],
+    *,
+    threshold: float,
+    max_steps: int,
+) -> Dict[str, Any]:
+    """Run the adaptive orchestration cycle."""
+    config = load_json(config_path)
+    graph_definition = config.get("graph_definition", {})
+    final_outputs: Dict[str, Any] = {}
+
+    for step in range(1, max_steps + 1):
+        llm = _create_llm_client(config)
+        orchestrator = GraphOrchestrator(graph_definition, llm, config)
+        try:
+            final_outputs = orchestrator.run(
+                initial_inputs=inputs.get("initial_inputs", {}),
+                project_base_output_dir=inputs.get("project_base_output_dir", "."),
+            )
+        finally:
+            if hasattr(llm, "close"):
+                llm.close()
+
+        new_graph = evaluate(final_outputs, graph_definition, threshold, step)
+        if not new_graph:
+            break
+
+        graph_definition = new_graph
+        config["graph_definition"] = graph_definition
+        save_json(config_path, config)
+
+    return final_outputs
+
+
+def _resolve_callable(path: str) -> Callable[[Dict[str, Any], Dict[str, Any], float, int], Optional[Dict[str, Any]]]:
+    """Resolve a callable from a ``module:function`` string."""
+    module_name, func_name = path.split(":")
+    module = importlib.import_module(module_name)
+    return getattr(module, func_name)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Adaptive Graph Runner")
+    parser.add_argument("--config", type=str, default="config.json", help="Path to configuration file.")
+    parser.add_argument(
+        "--inputs",
+        type=str,
+        required=True,
+        help="Path to JSON file with 'initial_inputs' and 'project_base_output_dir'.",
+    )
+    parser.add_argument("--eval-hook", type=str, default="", help="Evaluation hook specified as 'module:function'.")
+    parser.add_argument("--threshold", type=float, default=1.0, help="Evaluation threshold for termination.")
+    parser.add_argument("--max-steps", type=int, default=5, help="Maximum number of adaptation steps.")
+    args = parser.parse_args()
+
+    run_inputs = load_json(args.inputs)
+    evaluate = evaluate_target_function if not args.eval_hook else _resolve_callable(args.eval_hook)
+
+    adaptive_cycle(
+        args.config,
+        run_inputs,
+        evaluate,
+        threshold=args.threshold,
+        max_steps=args.max_steps,
+    )

--- a/adaptive/evaluation.py
+++ b/adaptive/evaluation.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from .mutation import mutate_graph_definition
+
+
+def evaluate_target_function(
+    outputs: Dict[str, Any],
+    graph_definition: Dict[str, Any],
+    threshold: float,
+    step: int,
+) -> Optional[Dict[str, Any]]:
+    """Evaluate ``outputs`` and decide whether to mutate the graph.
+
+    Parameters
+    ----------
+    outputs:
+        The result from the graph execution.
+    graph_definition:
+        Current graph definition.
+    threshold:
+        Desired score threshold to terminate the adaptation.
+    step:
+        Current evolution step.
+
+    Returns
+    -------
+    Optional[Dict[str, Any]]
+        A new graph definition if further adaptation is required or ``None`` to
+        stop the cycle.
+    """
+    score = outputs.get("score")
+    if score is not None and score >= threshold:
+        return None
+    return mutate_graph_definition(graph_definition, step)

--- a/adaptive/json_utils.py
+++ b/adaptive/json_utils.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+
+
+def load_json(path: str) -> Dict[str, Any]:
+    """Load JSON data from ``path``."""
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def save_json(path: str, data: Dict[str, Any]) -> None:
+    """Persist ``data`` to ``path`` as JSON."""
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)

--- a/adaptive/mutation.py
+++ b/adaptive/mutation.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+def mutate_graph_definition(graph_definition: Dict[str, Any], step: int) -> Dict[str, Any]:
+    """Return a mutated copy of ``graph_definition`` for the given ``step``.
+
+    This placeholder implementation simply annotates the graph with the current
+    evolution step. Real mutation logic can be inserted here.
+    """
+    mutated = dict(graph_definition)
+    metadata = dict(mutated.get("metadata", {}))
+    metadata["evolution_step"] = step
+    mutated["metadata"] = metadata
+    return mutated


### PR DESCRIPTION
## Summary
- refactor adaptive graph runner into a dedicated `adaptive` package
- include evaluation, mutation, and JSON utility modules to drive iterative adaptation until a threshold or step limit

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aca4ba2a4083319439ec091883b267