### PR TITLE
Add standalone rerun tool for adaptive experiments

### DIFF
--- a/adaptive/rerun_after_evaluation.py
+++ b/adaptive/rerun_after_evaluation.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+"""Re-run a graph after evaluating experimental results.
+
+This module provides a small utility for continuing an adaptive experimentation
+cycle once laboratory results have been gathered.  The evaluation results are
+recorded in a simple JSON "database" and the graph is executed again to propose
+new experimental conditions.
+"""
+
+import argparse
+from typing import Any, Dict
+
+from .adaptive_graph_runner import adaptive_cycle
+from .evaluation import evaluate_target_function
+from .json_utils import load_json, save_json
+
+
+def update_database(path: str, entry: Dict[str, Any]) -> None:
+    """Append ``entry`` to the JSON database at ``path``.
+
+    If the file does not exist, it is created with a top level ``experiments``
+    list.  Each ``entry`` typically contains the experimental conditions and
+    the measured property (e.g. yield or selectivity).
+    """
+    try:
+        db = load_json(path)
+    except FileNotFoundError:
+        db = {"experiments": []}
+    db.setdefault("experiments", []).append(entry)
+    save_json(path, db)
+
+
+def rerun_with_evaluation(
+    config_path: str,
+    inputs_path: str,
+    evaluation_path: str,
+    database_path: str,
+    *,
+    threshold: float,
+    max_steps: int,
+) -> None:
+    """Update the experiment database and run the adaptive cycle again."""
+    run_inputs = load_json(inputs_path)
+    evaluation_result = load_json(evaluation_path)
+    update_database(database_path, evaluation_result)
+
+    adaptive_cycle(
+        config_path,
+        run_inputs,
+        evaluate_target_function,
+        threshold=threshold,
+        max_steps=max_steps,
+    )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Re-run the graph after evaluating experiments."
+    )
+    parser.add_argument(
+        "--config",
+        type=str,
+        default="config.json",
+        help="Path to configuration file.",
+    )
+    parser.add_argument(
+        "--inputs",
+        type=str,
+        required=True,
+        help="Path to JSON file with 'initial_inputs' and 'project_base_output_dir'.",
+    )
+    parser.add_argument(
+        "--evaluation",
+        type=str,
+        required=True,
+        help="Path to JSON file containing the evaluation results.",
+    )
+    parser.add_argument(
+        "--database",
+        type=str,
+        required=True,
+        help="Path to the experiments database JSON file.",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=1.0,
+        help="Evaluation threshold for termination.",
+    )
+    parser.add_argument(
+        "--max-steps",
+        type=int,
+        default=5,
+        help="Maximum number of adaptation steps.",
+    )
+    args = parser.parse_args()
+
+    rerun_with_evaluation(
+        args.config,
+        args.inputs,
+        args.evaluation,
+        args.database,
+        threshold=args.threshold,
+        max_steps=args.max_steps,
+    )

--- a/tests/test_rerun_after_evaluation.py
+++ b/tests/test_rerun_after_evaluation.py
@@ -1,0 +1,52 @@
+import json
+from pathlib import Path
+
+from adaptive import rerun_after_evaluation
+
+
+def test_update_database(tmp_path):
+    db_path = tmp_path / "db.json"
+    rerun_after_evaluation.update_database(db_path, {"score": 0.5})
+    data = json.loads(db_path.read_text())
+    assert data["experiments"][0]["score"] == 0.5
+    rerun_after_evaluation.update_database(db_path, {"score": 0.7})
+    data = json.loads(db_path.read_text())
+    assert len(data["experiments"]) == 2
+
+
+def test_rerun_with_evaluation(monkeypatch, tmp_path):
+    calls = {}
+
+    def fake_cycle(config, inputs, eval_fn, threshold, max_steps):
+        calls["args"] = (config, inputs, eval_fn, threshold, max_steps)
+
+    monkeypatch.setattr(rerun_after_evaluation, "adaptive_cycle", fake_cycle)
+
+    config_path = tmp_path / "config.json"
+    inputs_path = tmp_path / "inputs.json"
+    evaluation_path = tmp_path / "evaluation.json"
+    db_path = tmp_path / "db.json"
+
+    config_path.write_text(json.dumps({"graph_definition": {}}))
+    inputs_path.write_text(
+        json.dumps({"initial_inputs": {}, "project_base_output_dir": "."})
+    )
+    evaluation_path.write_text(json.dumps({"score": 0.3}))
+
+    rerun_after_evaluation.rerun_with_evaluation(
+        str(config_path),
+        str(inputs_path),
+        str(evaluation_path),
+        str(db_path),
+        threshold=0.8,
+        max_steps=2,
+    )
+
+    db_data = json.loads(db_path.read_text())
+    assert db_data["experiments"][0]["score"] == 0.3
+    args = calls["args"]
+    assert args[0] == str(config_path)
+    assert args[1] == {"initial_inputs": {}, "project_base_output_dir": "."}
+    assert callable(args[2])
+    assert args[3] == 0.8
+    assert args[4] == 2


### PR DESCRIPTION
## Summary
- add `rerun_after_evaluation` utility to append lab results to a JSON database and execute the adaptive graph again
- cover new functionality with tests for database updates and orchestrator invocation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aca836b9088331950ce2ab4ee1c6ac