### PR TITLE
Remove unused globals in app config loader

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -63,8 +63,6 @@ def load_app_config(config_path="config.json", main_script_dir=None):
     module-level ``APP_CONFIG`` dictionary, mutating global state.
     Returns the config dictionary on success, None on failure.
     """
-    global openai_errors, OPENAI_SDK_AVAILABLE, APP_CONFIG
-
     if main_script_dir and not os.path.isabs(config_path):
         resolved_config_path = os.path.join(main_script_dir, config_path)
     else:


### PR DESCRIPTION
## Summary
- clean up `load_app_config` by removing unused global declarations

## Testing
- `pytest`
- ⚠️ `python -m flake8 utils.py` (flake8 missing)

------
https://chatgpt.com/codex/tasks/task_e_68ae280b1b148331bc48cae8acd758e8