### PR TITLE
Limit flake8 checks to syntax and name errors

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+select = E9,F63,F7,F82


### PR DESCRIPTION
## Summary
- configure flake8 to only flag syntax errors and undefined names

## Testing
- `pip install flake8` *(fails: Could not find a version that satisfies the requirement flake8)*
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68ae2a6306a88331957fb4b9dc517541