### PR TITLE
Add module docstrings and tidy imports

### DIFF
--- a/adaptive/evaluation.py
+++ b/adaptive/evaluation.py
@@ -1,3 +1,10 @@
+"""Helper functions for evaluating adaptive graph outputs.
+
+This module exposes :func:`evaluate_target_function`, a small utility used by
+the adaptive workflow to decide whether further mutation of the graph is
+required based on the score returned from a run.
+"""
+
 from __future__ import annotations
 
 from typing import Any, Dict, Optional

--- a/adaptive/json_utils.py
+++ b/adaptive/json_utils.py
@@ -1,3 +1,5 @@
+"""Utilities for working with JSON files in the adaptive workflow."""
+
 from __future__ import annotations
 
 import json

--- a/adaptive/mutation.py
+++ b/adaptive/mutation.py
@@ -1,3 +1,5 @@
+"""Graph mutation utilities used during adaptive optimisation."""
+
 from __future__ import annotations
 
 from typing import Any, Dict

--- a/adaptive/rerun_after_evaluation.py
+++ b/adaptive/rerun_after_evaluation.py
@@ -1,12 +1,12 @@
-from __future__ import annotations
-
 """Re-run a graph after evaluating experimental results.
 
 This module provides a small utility for continuing an adaptive experimentation
-cycle once laboratory results have been gathered.  The evaluation results are
+cycle once laboratory results have been gathered. The evaluation results are
 recorded in a simple JSON "database" and the graph is executed again to propose
 new experimental conditions.
 """
+
+from __future__ import annotations
 
 import argparse
 from typing import Any, Dict
@@ -39,7 +39,7 @@ def rerun_with_evaluation(
     *,
     threshold: float,
     max_steps: int,
-) -> None:
+) -> None:  # pylint: disable=too-many-arguments
     """Update the experiment database and run the adaptive cycle again."""
     run_inputs = load_json(inputs_path)
     evaluation_result = load_json(evaluation_path)

--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,3 +1,5 @@
+"""Convenience imports and registry initialisation for agent classes."""
+
 from .registry import (
     AGENT_REGISTRY,
     AgentPlugin,


### PR DESCRIPTION
## Summary
- document adaptive evaluation, JSON utilities, mutation helpers, and rerun script
- document agents package and clean up imports
- include pylint suppression for rerun helper

## Testing
- `pytest`
- `python -m pylint adaptive/evaluation.py adaptive/json_utils.py adaptive/mutation.py adaptive/rerun_after_evaluation.py agents/__init__.py` *(fails: No module named pylint)*
- `pip install pylint` *(fails: Could not find a version that satisfies the requirement pylint: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ae37f2cdc483318b41ce0c0357ee69