### PR TITLE
fix: address pylint warnings in base agent

### DIFF
--- a/agents/base_agent.py
+++ b/agents/base_agent.py
@@ -1,3 +1,5 @@
+"""Base functionality for MACS agents that utilise a language model."""
+
 from typing import Optional, Dict, Any
 
 from llm import LLMClient
@@ -7,7 +9,7 @@ from utils import get_model_name, get_prompt_text, log_status
 class Agent:
     """Base class for all MACS agents that interact with an LLM."""
 
-    def __init__(self, agent_id, agent_type, config_params=None, llm: LLMClient = None, app_config: Dict[str, Any] = None):
+    def __init__(self, agent_id, agent_type, config_params=None, llm: LLMClient = None, app_config: Dict[str, Any] = None):  # pylint: disable=too-many-arguments,too-many-positional-arguments
         """Initialise a generic agent.
 
         Parameters
@@ -59,7 +61,7 @@ class Agent:
                 return self.system_message
         return self.system_message
 
-    def execute(self, inputs: dict) -> dict:
+    def execute(self, _inputs: dict) -> dict:
         """Execute the agent's primary behaviour.
 
         Subclasses must override this method. The base implementation only


### PR DESCRIPTION
## Summary
- add module docstring for base agent
- suppress lint warnings for argument counts
- rename unused `inputs` parameter to `_inputs`

## Testing
- `pytest -q`
- `pylint agents/base_agent.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae380736f48331a3131e8cdeda63c6