### PR TITLE
Fix import order and add docstring for experiment designer agent

### DIFF
--- a/agents/experiment_designer_agent.py
+++ b/agents/experiment_designer_agent.py
@@ -1,7 +1,9 @@
-from .base_agent import Agent
-from .registry import register_agent
+"""Agent for designing experiments based on hypotheses."""
+
 from utils import log_status
 from llm import LLMError
+from .base_agent import Agent
+from .registry import register_agent
 
 @register_agent("ExperimentDesignerAgent")
 class ExperimentDesignerAgent(Agent):


### PR DESCRIPTION
## Summary
- add module docstring for experiment designer agent
- reorder imports so project modules precede relative imports

## Testing
- `pip install pylint` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae382a7390833189ba6c9f1b35c63e