### PR TITLE
Refactor hypothesis generator to satisfy lint

### DIFF
--- a/agents/hypothesis_generator_agent.py
+++ b/agents/hypothesis_generator_agent.py
@@ -1,8 +1,11 @@
+"""Agent for generating hypotheses from an integrated knowledge brief."""
+
 import json
+from llm import LLMError
+from utils import log_status
 from .base_agent import Agent
 from .registry import register_agent
-from utils import log_status
-from llm import LLMError
+
 
 @register_agent("HypothesisGeneratorAgent")
 class HypothesisGeneratorAgent(Agent):
@@ -10,46 +13,57 @@ class HypothesisGeneratorAgent(Agent):
 
     def execute(self, inputs: dict) -> dict:  # Type hint for dict
         """Generate a list of hypotheses and key opportunities."""
-        num_hypotheses_to_generate = self.config_params.get("num_hypotheses", 3)
+        num_hypotheses = self.config_params.get("num_hypotheses", 3)
         try:
-            num_hypotheses_to_generate = int(num_hypotheses_to_generate)
-            if num_hypotheses_to_generate <= 0:
-                num_hypotheses_to_generate = 3 # Default to 3 if invalid
+            num_hypotheses = int(num_hypotheses)
+            if num_hypotheses <= 0:
+                num_hypotheses = 3
                 log_status(
-                    f"[{self.agent_id}] WARNING: Invalid 'num_hypotheses' config: {self.config_params.get('num_hypotheses')}. Defaulting to 3.")
+                    f"[{self.agent_id}] WARNING: Invalid 'num_hypotheses' config: {self.config_params.get('num_hypotheses')}. Defaulting to 3."
+                )
         except ValueError:
-            num_hypotheses_to_generate = 3 # Default to 3 if not an int
+            num_hypotheses = 3
             log_status(
-                f"[{self.agent_id}] WARNING: Non-integer 'num_hypotheses' config: {self.config_params.get('num_hypotheses')}. Defaulting to 3.")
+                f"[{self.agent_id}] WARNING: Non-integer 'num_hypotheses' config: {self.config_params.get('num_hypotheses')}. Defaulting to 3."
+            )
 
-        format_args = {"num_hypotheses": num_hypotheses_to_generate}
+        format_args = {"num_hypotheses": num_hypotheses}
         current_system_message = self.get_formatted_system_message(format_kwargs=format_args)
-
         if current_system_message.startswith("ERROR:"):
-            return {"hypotheses_output_blob": "", "hypotheses_list": [], "key_opportunities": "",
-                    "error": current_system_message}
+            return {
+                "hypotheses_output_blob": "",
+                "hypotheses_list": [],
+                "key_opportunities": "",
+                "error": current_system_message,
+            }
 
-        integrated_knowledge_brief = inputs.get("integrated_knowledge_brief")
-        if inputs.get("integrated_knowledge_brief_error") or not integrated_knowledge_brief:
+        integrated_brief = inputs.get("integrated_knowledge_brief")
+        if inputs.get("integrated_knowledge_brief_error") or not integrated_brief:
             error_msg = (
                 "Invalid or missing integrated knowledge brief for hypothesis generation. "
-                f"Upstream error: {inputs.get('error', integrated_knowledge_brief)}"
+                f"Upstream error: {inputs.get('error', integrated_brief)}"
             )
             log_status(f"[{self.agent_id}] INPUT_ERROR: {error_msg}")
-            return {"hypotheses_output_blob": "", "hypotheses_list": [], "key_opportunities": "", "error": error_msg}
+            return {
+                "hypotheses_output_blob": "",
+                "hypotheses_list": [],
+                "key_opportunities": "",
+                "error": error_msg,
+            }
 
         max_brief_len = self.config_params.get("max_brief_len", 15000)
-        if len(integrated_knowledge_brief) > max_brief_len:
+        if len(integrated_brief) > max_brief_len:
             log_status(
-                f"[{self.agent_id}] INFO: Truncating integrated_knowledge_brief from {len(integrated_knowledge_brief)} to {max_brief_len} for hypothesis generation.")
-            integrated_knowledge_brief = integrated_knowledge_brief[:max_brief_len]
+                f"[{self.agent_id}] INFO: Truncating integrated_knowledge_brief from {len(integrated_brief)} to {max_brief_len} for hypothesis generation."
+            )
+            integrated_brief = integrated_brief[:max_brief_len]
 
         user_prompt = (
-            f"Based on the following 'Integrated Knowledge Brief':\n\n---\n{integrated_knowledge_brief}\n---\n\n"
-            f"Please provide your analysis, key research opportunities, and propose exactly {num_hypotheses_to_generate} hypotheses "
+            f"Based on the following 'Integrated Knowledge Brief':\n\n---\n{integrated_brief}\n---\n\n"
+            f"Please provide your analysis, key research opportunities, and propose exactly {num_hypotheses} hypotheses "
             "strictly in the specified JSON format."
         )
-        log_status(f"[{self.agent_id}] Requesting {num_hypotheses_to_generate} hypotheses from LLM.")
+        log_status(f"[{self.agent_id}] Requesting {num_hypotheses} hypotheses from LLM.")
         temperature = float(self.config_params.get("temperature", 0.6))
         try:
             llm_response_str = self.llm.complete(
@@ -66,51 +80,71 @@ class HypothesisGeneratorAgent(Agent):
                 "error": f"LLM call failed: {e}",
             }
 
+        return self._parse_llm_output(llm_response_str)
+
+    def _parse_llm_output(self, llm_response_str: str) -> dict:
+        """Parse the LLM response JSON into structured hypotheses."""
         try:
-            # Attempt to clean up markdown code block fences if present
-            cleaned_llm_response_str = llm_response_str
-            if cleaned_llm_response_str.strip().startswith("```json"):
-                cleaned_llm_response_str = cleaned_llm_response_str.strip()[len("```json"):].strip()
-            if cleaned_llm_response_str.strip().endswith("```"):
-                cleaned_llm_response_str = cleaned_llm_response_str.strip()[:-len("```")].strip()
+            cleaned = llm_response_str.strip()
+            if cleaned.startswith("```json"):
+                cleaned = cleaned[len("```json"):].strip()
+            if cleaned.endswith("```"):
+                cleaned = cleaned[:-len("```")].strip()
 
-            parsed_output = json.loads(cleaned_llm_response_str)
+            parsed_output = json.loads(cleaned)
             key_opportunities = parsed_output.get("key_opportunities", "")
-            hypotheses_data = parsed_output.get("hypotheses", []) # This should be a list of objects now
-
+            hypotheses_data = parsed_output.get("hypotheses", [])
             if not isinstance(key_opportunities, str):
-                key_opportunities = str(key_opportunities) # Ensure string
+                key_opportunities = str(key_opportunities)
 
             valid_hypotheses_list = []
             if isinstance(hypotheses_data, list):
                 for idx, hypo_item in enumerate(hypotheses_data):
-                    if isinstance(hypo_item, dict) and \
-                       isinstance(hypo_item.get('hypothesis'), str) and \
-                       isinstance(hypo_item.get('justification'), str):
-                        valid_hypotheses_list.append({
-                            "hypothesis": hypo_item['hypothesis'].strip(),
-                            "justification": hypo_item['justification'].strip()
-                        })
+                    if (
+                        isinstance(hypo_item, dict)
+                        and isinstance(hypo_item.get("hypothesis"), str)
+                        and isinstance(hypo_item.get("justification"), str)
+                    ):
+                        valid_hypotheses_list.append(
+                            {
+                                "hypothesis": hypo_item["hypothesis"].strip(),
+                                "justification": hypo_item["justification"].strip(),
+                            }
+                        )
                     else:
-                        log_status(f"[{self.agent_id}] WARNING: Invalid hypothesis item structure at index {idx}. Item: {str(hypo_item)[:100]}. Expected dict with 'hypothesis' and 'justification' strings.")
+                        log_status(
+                            f"[{self.agent_id}] WARNING: Invalid hypothesis item structure at index {idx}. Item: {str(hypo_item)[:100]}. Expected dict with 'hypothesis' and 'justification' strings."
+                        )
             else:
-                log_status(f"[{self.agent_id}] WARNING: 'hypotheses' field is not a list or missing. LLM Output: {cleaned_llm_response_str[:500]}")
-                # valid_hypotheses_list remains empty
+                log_status(
+                    f"[{self.agent_id}] WARNING: 'hypotheses' field is not a list or missing. LLM Output: {cleaned[:500]}"
+                )
 
             log_status(
-                f"[{self.agent_id}] Successfully parsed hypotheses. Opportunities: '{key_opportunities[:50]}...', Valid hypotheses count: {len(valid_hypotheses_list)}")
+                f"[{self.agent_id}] Successfully parsed hypotheses. Opportunities: '{key_opportunities[:50]}...', Valid hypotheses count: {len(valid_hypotheses_list)}"
+            )
             return {
-                "hypotheses_output_blob": llm_response_str, # Original response for debugging
-                "hypotheses_list": valid_hypotheses_list,   # List of dicts
-                "key_opportunities": key_opportunities
+                "hypotheses_output_blob": llm_response_str,
+                "hypotheses_list": valid_hypotheses_list,
+                "key_opportunities": key_opportunities,
             }
         except json.JSONDecodeError as e:
             log_status(
-                f"[{self.agent_id}] HYPOTHESIS_PARSE_ERROR: Failed to parse JSON from LLM response. Error: {e}. Response (first 500 chars): {llm_response_str[:500]}...")
-            return {"hypotheses_output_blob": llm_response_str, "hypotheses_list": [], "key_opportunities": "",
-                    "error": f"Failed to parse JSON from LLM: {e}. Response: {llm_response_str[:200]}"}
-        except Exception as e: # Catch any other unexpected error during parsing
+                f"[{self.agent_id}] HYPOTHESIS_PARSE_ERROR: Failed to parse JSON from LLM response. Error: {e}. Response (first 500 chars): {llm_response_str[:500]}..."
+            )
+            return {
+                "hypotheses_output_blob": llm_response_str,
+                "hypotheses_list": [],
+                "key_opportunities": "",
+                "error": f"Failed to parse JSON from LLM: {e}. Response: {llm_response_str[:200]}",
+            }
+        except (ValueError, TypeError) as e:
             log_status(
-                f"[{self.agent_id}] HYPOTHESIS_UNEXPECTED_PARSE_ERROR: An unexpected error occurred while parsing LLM output: {e}. Response (first 500 chars): {llm_response_str[:500]}...")
-            return {"hypotheses_output_blob": llm_response_str, "hypotheses_list": [], "key_opportunities": "",
-                    "error": f"Unexpected error parsing LLM output: {e}"}
+                f"[{self.agent_id}] HYPOTHESIS_UNEXPECTED_PARSE_ERROR: An error occurred while parsing LLM output: {e}. Response (first 500 chars): {llm_response_str[:500]}..."
+            )
+            return {
+                "hypotheses_output_blob": llm_response_str,
+                "hypotheses_list": [],
+                "key_opportunities": "",
+                "error": f"Error parsing LLM output: {e}",
+            }


### PR DESCRIPTION
## Summary
- add module docstring and reorder imports
- simplify execute by moving parsing logic into a helper
- handle JSON parse errors without broad exceptions

## Testing
- `pytest`
- `pip install pylint` *(fails: Could not find a version that satisfies the requirement pylint)*

------
https://chatgpt.com/codex/tasks/task_e_68ae383aefe48331a4ad96d82cc06740