### PR TITLE
Add docstring and fix import order in KnowledgeIntegratorAgent

### DIFF
--- a/agents/knowledge_integrator_agent.py
+++ b/agents/knowledge_integrator_agent.py
@@ -1,6 +1,9 @@
+"""Agent that integrates multiple knowledge sources into a coherent brief."""
+
+from llm import LLMError
+
 from .base_agent import Agent
 from .registry import register_agent
-from llm import LLMError
 # log_status is available via base_agent.py, or if not, would need to be imported if used directly here
 
 @register_agent("KnowledgeIntegratorAgent")


### PR DESCRIPTION
## Summary
- add module docstring describing KnowledgeIntegratorAgent
- reorder imports so LLMError precedes local Agent imports

## Testing
- `pytest`
- `flake8 agents/knowledge_integrator_agent.py` *(fails: command not found, attempted install but failed)*
- `pylint agents/knowledge_integrator_agent.py` *(fails: command not found, attempted install but failed)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3844d88c8331989f8363b0d45c3f