### PR TITLE
Refactor multi-doc synthesizer imports and variables

### DIFF
--- a/agents/multi_doc_synthesizer_agent.py
+++ b/agents/multi_doc_synthesizer_agent.py
@@ -1,44 +1,69 @@
+"""Agent for synthesizing summaries from multiple documents."""
+
 import os
+
+from llm import LLMError
+from utils import log_status
+
 from .base_agent import Agent
 from .registry import register_agent
-from utils import log_status
-from llm import LLMError
+
 
 @register_agent("MultiDocSynthesizerAgent")
 class MultiDocSynthesizerAgent(Agent):
     """Combine individual document summaries into a holistic synthesis."""
 
-    def execute(self, inputs: dict) -> dict:  # Type hint for dict
+    def execute(self, inputs: dict) -> dict:
         """Produce a cross-document synthesis from a list of summaries."""
         current_system_message = self.get_formatted_system_message()
         if current_system_message.startswith("ERROR:"):
             return {"multi_doc_synthesis_output": "", "error": current_system_message}
+
         summaries_list = inputs.get("all_pdf_summaries")
         if not summaries_list or not isinstance(summaries_list, list):
             if inputs.get("all_pdf_summaries_error"):
-                error_msg = f"Upstream error providing PDF summaries: {inputs.get('error', 'Unknown upstream error')}"
+                error_msg = (
+                    "Upstream error providing PDF summaries: "
+                    f"{inputs.get('error', 'Unknown upstream error')}"
+                )
                 log_status(f"[{self.agent_id}] INPUT_ERROR: {error_msg}")
                 return {"multi_doc_synthesis_output": "", "error": error_msg}
             log_status(
-                f"[{self.agent_id}] INPUT_ERROR: No PDF summaries provided or input is not a list. Received: {type(summaries_list)}")
-            return {"multi_doc_synthesis_output": "", "error": "No PDF summaries provided or input is not a list."}
+                f"[{self.agent_id}] INPUT_ERROR: No PDF summaries provided or input is not a list. "
+                f"Received: {type(summaries_list)}"
+            )
+            return {
+                "multi_doc_synthesis_output": "",
+                "error": "No PDF summaries provided or input is not a list.",
+            }
 
-        valid_summaries = [s for s in summaries_list if isinstance(s, dict) and s.get("summary") and not s.get("error")]
+        valid_summaries = [
+            s
+            for s in summaries_list
+            if isinstance(s, dict) and s.get("summary") and not s.get("error")
+        ]
         if not valid_summaries:
             log_status(
-                f"[{self.agent_id}] INPUT_ERROR: No valid (non-error) PDF summaries available for synthesis out of {len(summaries_list)} received.")
-            return {"multi_doc_synthesis_output": "", "error": "No valid PDF summaries available for synthesis."}
+                f"[{self.agent_id}] INPUT_ERROR: No valid (non-error) PDF summaries available for synthesis "
+                f"out of {len(summaries_list)} received."
+            )
+            return {
+                "multi_doc_synthesis_output": "",
+                "error": "No valid PDF summaries available for synthesis.",
+            }
 
-        formatted_summaries = []
-        for i, item in enumerate(valid_summaries):
-            pdf_name = os.path.basename(item.get("original_pdf_path", f"Document {i + 1}"))
-            formatted_summaries.append(f"Summary from '{pdf_name}':\n{item['summary']}\n---")
+        combined_summaries_text = "\n\n".join(
+            f"Summary from '{os.path.basename(item.get('original_pdf_path', f'Document {i + 1}'))}':\n"
+            f"{item['summary']}\n---"
+            for i, item in enumerate(valid_summaries)
+        )
 
-        combined_summaries_text = "\n\n".join(formatted_summaries)
         max_combined_len = self.config_params.get("max_combined_len", 30000)
         if len(combined_summaries_text) > max_combined_len:
             log_status(
-                f"[{self.agent_id}] INFO: Truncating combined summaries from {len(combined_summaries_text)} to {max_combined_len} chars for synthesis.")
+                f"[{self.agent_id}] INFO: Truncating combined summaries from {len(combined_summaries_text)} to "
+                f"{max_combined_len} chars for synthesis."
+            )
             combined_summaries_text = combined_summaries_text[:max_combined_len]
 
         temperature = float(self.config_params.get("temperature", 0.6))
@@ -57,3 +82,4 @@ class MultiDocSynthesizerAgent(Agent):
         except LLMError as e:
             return {"multi_doc_synthesis_output": "", "error": str(e)}
         return {"multi_doc_synthesis_output": synthesis_output}
+


### PR DESCRIPTION
## Summary
- add module docstring and reorder imports in `MultiDocSynthesizerAgent`
- reduce local variables by building combined summary in a single comprehension

## Testing
- `pytest`
- Unable to run `pylint agents/multi_doc_synthesizer_agent.py` (pylint installation failed with 403 error)


------
https://chatgpt.com/codex/tasks/task_e_68ae3858aa808331b3b66b485f24b196