### PR TITLE
chore: clean up lint warnings in agents

### DIFF
--- a/agents/observer_agent.py
+++ b/agents/observer_agent.py
@@ -1,7 +1,11 @@
+"""Observer agent for reviewing agent outputs and reporting errors."""
+
 from typing import Dict
+
+from utils import log_status
+
 from .base_agent import Agent
 from .registry import register_agent
-from utils import log_status
 
 @register_agent("ObserverAgent")
 class ObserverAgent(Agent):

--- a/agents/pdf_loader_agent.py
+++ b/agents/pdf_loader_agent.py
@@ -1,7 +1,11 @@
+"""Agent that loads PDF files and extracts their raw text content."""
+
 import os
+
+from utils import log_status, PyPDF2  # PyPDF2 needed for PyPDF2.PdfReader
+
 from .base_agent import Agent
 from .registry import register_agent
-from utils import log_status, PyPDF2  # PyPDF2 needed for PyPDF2.PdfReader
 
 @register_agent("PDFLoaderAgent")
 class PDFLoaderAgent(Agent):
@@ -12,40 +16,39 @@ class PDFLoaderAgent(Agent):
         pdf_path = inputs.get("pdf_path")
         if not pdf_path:
             return {"pdf_text_content": "", "error": "PDF path not provided."}
-        # Ensure log_status is available or handled if this agent is truly standalone.
         if not PyPDF2:
             return {"pdf_text_content": "", "error": "PyPDF2 library not available."}
+
         log_status(f"[{self.agent_id}] PDF_LOAD_START: Path='{pdf_path}'")
         if not os.path.exists(pdf_path):
             return {"pdf_text_content": "", "error": f"PDF file not found: {pdf_path}"}
-        try:
-            if os.path.getsize(pdf_path) == 0:
-                return {"pdf_text_content": "", "error": f"PDF file is empty: {pdf_path}"}
-        except OSError as oe:
-            return {"pdf_text_content": "", "error": f"Could not access file for size check: {pdf_path}, {oe}"}
+
+        error = ""
         text_content = ""
         try:
-            with open(pdf_path, 'rb') as pdf_file_obj:
-                pdf_reader = PyPDF2.PdfReader(pdf_file_obj)
-                if pdf_reader.is_encrypted:
-                    if pdf_reader.decrypt('') == 0:
-                        log_status(
-                            f"[{self.agent_id}] PDF_LOAD_ERROR: Failed to decrypt PDF '{os.path.basename(pdf_path)}'."
-                        )
-                        return {
-                            "pdf_text_content": "",
-                            "error": f"Failed to decrypt PDF: {os.path.basename(pdf_path)}.",
-                        }
+            if os.path.getsize(pdf_path) == 0:
+                error = f"PDF file is empty: {pdf_path}"
+            else:
+                with open(pdf_path, "rb") as pdf_file_obj:
+                    pdf_reader = PyPDF2.PdfReader(pdf_file_obj)
+                    if pdf_reader.is_encrypted and pdf_reader.decrypt("") == 0:
+                        error = f"Failed to decrypt PDF: {os.path.basename(pdf_path)}."
+                    else:
+                        if pdf_reader.is_encrypted:
+                            log_status(
+                                f"[{self.agent_id}] PDF_LOAD_INFO: PDF '{os.path.basename(pdf_path)}' decrypted."
+                            )
+                        for page_obj in pdf_reader.pages:
+                            text_content += page_obj.extract_text() or ""
+                if not error and not text_content.strip():
                     log_status(
-                        f"[{self.agent_id}] PDF_LOAD_INFO: PDF '{os.path.basename(pdf_path)}' decrypted."
+                        f"[{self.agent_id}] PDF_LOAD_WARNING: No text extracted from '{os.path.basename(pdf_path)}'."
                     )
-                for page_obj in pdf_reader.pages:
-                    text_content += page_obj.extract_text() or ""
-            if not text_content.strip():
-                log_status(
-                    f"[{self.agent_id}] PDF_LOAD_WARNING: No text extracted from '{os.path.basename(pdf_path)}'."
-                )
-            return {"pdf_text_content": text_content, "original_pdf_path": pdf_path}
-        except Exception as e:
-            log_status(f"[{self.agent_id}] PDF_LOAD_ERROR: PDF extraction failed for {pdf_path}: {e}")
-            return {"pdf_text_content": "", "error": f"PDF extraction failed for {pdf_path}: {e}"}
+        except (OSError, PyPDF2.errors.PdfReadError) as e:
+            error = f"PDF extraction failed for {pdf_path}: {e}"
+
+        if error:
+            log_status(f"[{self.agent_id}] PDF_LOAD_ERROR: {error}")
+            return {"pdf_text_content": "", "error": error}
+
+        return {"pdf_text_content": text_content, "original_pdf_path": pdf_path}

--- a/agents/pdf_summarizer_agent.py
+++ b/agents/pdf_summarizer_agent.py
@@ -1,8 +1,12 @@
+"""Agent that produces summaries of PDF text content."""
+
 import os
-from .base_agent import Agent
-from .registry import register_agent
+
 from utils import log_status
 from llm import LLMError
+
+from .base_agent import Agent
+from .registry import register_agent
 
 @register_agent("PDFSummarizerAgent")
 class PDFSummarizerAgent(Agent):

--- a/agents/registry.py
+++ b/agents/registry.py
@@ -1,9 +1,12 @@
-import pkgutil
+"""Registry utilities for managing built-in agents and external plugins."""
+
 import importlib
+import pkgutil
 import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Type
+
 from utils import log_status
 
 MACS_VERSION = "1.0"
@@ -61,16 +64,16 @@ def get_agent_class(name: str):
     return entry
 
 
-def load_agents(package_name: str = __name__):
+def load_agents(package_name: str = __package__):
     """Dynamically import modules ending with '_agent' to populate the registry."""
-    package = importlib.import_module(__package__)
+    package = importlib.import_module(package_name)
     package_path = package.__path__
 
-    log_status(f"--- Starting Agent Loading from package: '{__package__}' ---")
+    log_status(f"--- Starting Agent Loading from package: '{package_name}' ---")
 
     for _, module_name, _ in pkgutil.iter_modules(package_path):
         if module_name.endswith('_agent'):
-            full_module_name = f"{__package__}.{module_name}"
+            full_module_name = f"{package_name}.{module_name}"
             try:
                 importlib.import_module(full_module_name)
                 log_status(f"  [SUCCESS] Successfully imported agent module: '{module_name}'")
@@ -78,7 +81,9 @@ def load_agents(package_name: str = __name__):
                 log_status(f"  [FAILURE] Failed to import agent module '{module_name}'. Error: {e}")
                 continue
 
-    log_status(f"--- Agent Loading Complete. Registered agents: {list(AGENT_REGISTRY.keys())} ---")
+    log_status(
+        f"--- Agent Loading Complete. Registered agents: {list(AGENT_REGISTRY.keys())} ---"
+    )
 
 
 def load_plugins(path: str = 'agent_plugins'):


### PR DESCRIPTION
## Summary
- add missing module docstrings and correct import order in agent modules
- centralize PDF loader error handling and narrow exception catching
- document registry utilities and honor package_name in load_agents

## Testing
- `pytest`
- `pip install pylint` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3893202083318589867bb384c30b