### PR TITLE
Refactor cache and CLI test scripts for lint compliance

### DIFF
--- a/cache.py
+++ b/cache.py
@@ -1,8 +1,10 @@
+"""Utility classes for file-backed caching of embedding computations."""
+
 import os
 import json
 import hashlib
 from threading import Lock
-from typing import Any, Optional, Tuple
+from typing import Any, Optional
 
 class Cache:
     """Simple JSON-backed cache for deterministic computations."""
@@ -15,7 +17,7 @@ class Cache:
             try:
                 with open(cache_file, 'r', encoding='utf-8') as f:
                     self.data = json.load(f)
-            except Exception:
+            except (OSError, json.JSONDecodeError):
                 # Corrupted cache is ignored
                 self.data = {}
 


### PR DESCRIPTION
## Summary
- add module docstrings and tighten exception handling in cache utility
- restructure CLI test into a `main` function, add docstrings and encoding, and use `sys.exit`

## Testing
- `pytest`
- ⚠️ `python -m pylint cache.py cli_test.py` *(pylint not installed; install attempt failed)*

------
https://chatgpt.com/codex/tasks/task_e_68ae38999a448331a95f4429731f20d6