### PR TITLE
Refactor LLM interfaces to satisfy lint

### DIFF
--- a/llm.py
+++ b/llm.py
@@ -1,3 +1,5 @@
+"""Interfaces and protocol definitions for LLM backends."""
+
 from typing import Protocol, Optional, Dict, Any
 
 
@@ -8,7 +10,12 @@ class LLMError(Exception):
 class LLMClient(Protocol):
     """Protocol describing the minimum interface for LLM backends."""
 
-    def __init__(self, app_config: Dict[str, Any], api_key: Optional[str] = None, timeout: int = 120):
+    def __init__(
+        self,
+        app_config: Dict[str, Any],
+        api_key: Optional[str] = None,
+        timeout: int = 120,
+    ) -> None:
         """Initialize the client.
 
         Parameters
@@ -20,9 +27,9 @@ class LLMClient(Protocol):
         timeout:
             Maximum time in seconds to wait for network responses.
         """
-        ...
+        raise NotImplementedError
 
-    def complete(
+    def complete(  # pylint: disable=too-many-arguments
         self,
         *,
         system: str,
@@ -32,12 +39,12 @@ class LLMClient(Protocol):
         extra: Optional[Dict] = None,
     ) -> str:
         """Perform a chat completion request and return the model output."""
-        ...
+        raise NotImplementedError
 
     def get_embeddings_client(self) -> Any:
         """Returns a cached embedding client if available."""
-        ...
+        raise NotImplementedError
 
     def close(self) -> None:
         """Releases any underlying resources held by the client."""
-        ...
+        raise NotImplementedError

--- a/llm_fake.py
+++ b/llm_fake.py
@@ -1,3 +1,5 @@
+"""Fake LLM implementation used solely for testing."""
+
 import json
 from typing import Optional
 from cache import Cache
@@ -14,7 +16,7 @@ class FakeLLM:
         self._embedding_client = self
         self._cache = cache or Cache()
 
-    def get_response(self, system_message, user_message, model, temperature):
+    def get_response(self, _system_message, user_message, _model, _temperature):
         """Return a deterministic response for ``user_message``."""
         if user_message in self.response_map:
             return self.response_map[user_message]
@@ -28,7 +30,7 @@ class FakeLLM:
                     }
                 ]
             })
-        return f"[FAKE] ok"
+        return "[FAKE] ok"
 
     def complete(self, system, prompt, model, temperature=0.1):
         """Simulate a completion call with simple caching."""
@@ -44,11 +46,11 @@ class FakeLLM:
         """Return a dummy embeddings client (self)."""
         return self._embedding_client
 
-    def embeddings(self, input, model):
+    def embeddings(self, _input, _model):
         """Return a dummy embedding structure."""
         return self
 
-    def create(self, input, model):
+    def create(self, _input, _model):
         """Return a dummy embedding structure."""
         return self
 


### PR DESCRIPTION
## Summary
- add module docstrings and enforce NotImplementedError for protocol methods
- clean up FakeLLM placeholder implementation and rename unused variables

## Testing
- `pytest` *(fails: tests/test_orchestrator.py::TestGraphOrchestrator::test_full_graph_run_with_memory_agents - AssertionError: 'deep_rese...')*


------
https://chatgpt.com/codex/tasks/task_e_68ae38c7977883319d7493cfc54f63df