### PR TITLE
Add docstrings and lint fixes for test modules

### DIFF
--- a/tests/test_agent_integration.py
+++ b/tests/test_agent_integration.py
@@ -1,3 +1,5 @@
+"""Integration tests verifying agent collaboration."""
+
 import os
 import unittest
 
@@ -9,7 +11,10 @@ from llm_fake import FakeLLM
 
 
 class TestAgentIntegration(unittest.TestCase):
+    """Validate that core agents can run through an entire pipeline."""
+
     def setUp(self):
+        """Prepare fake agents and configuration for testing."""
         os.environ["OPENAI_API_KEY"] = "dummy_key"
         self.app_config = {
             "system_variables": {"models": {}},
@@ -49,9 +54,11 @@ class TestAgentIntegration(unittest.TestCase):
         )
 
     def tearDown(self):
+        """Remove fake API key from environment."""
         del os.environ["OPENAI_API_KEY"]
 
     def test_pipeline(self):
+        """Ensure each agent processes and passes data as expected."""
         summaries = [
             {"summary": "First", "original_pdf_path": "doc1.pdf"},
             {"summary": "Second", "original_pdf_path": "doc2.pdf"},

--- a/tests/test_call_openai_api.py
+++ b/tests/test_call_openai_api.py
@@ -1,8 +1,11 @@
+"""Tests for the helper function that invokes the OpenAI API."""
+
 import llm_openai
 from utils import call_openai_api, APP_CONFIG
 
 
 def test_call_openai_api_passes_app_config(monkeypatch):
+    """Ensure call_openai_api forwards configuration and parameters correctly."""
     # Prepare application configuration
     APP_CONFIG.clear()
     APP_CONFIG.update({
@@ -14,13 +17,17 @@ def test_call_openai_api_passes_app_config(monkeypatch):
 
     captured = {}
 
-    class DummyLLM:
+    class DummyLLM:  # pylint: disable=too-few-public-methods
+        """Simple stand-in for the real OpenAI LLM class."""
+
         def __init__(self, app_config, api_key=None, timeout=0):
+            """Record constructor arguments for later assertions."""
             captured["app_config"] = app_config
             captured["api_key"] = api_key
             captured["timeout"] = timeout
 
         def complete(self, system, prompt, model=None, temperature=None):
+            """Record completion parameters and return a dummy response."""
             captured["system"] = system
             captured["prompt"] = prompt
             captured["model"] = model

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -1,3 +1,5 @@
+"""Tests for validating the configuration schema of the orchestrator."""
+
 import os
 import unittest
 
@@ -8,13 +10,18 @@ from llm_fake import FakeLLM
 
 
 class TestConfigSchema(unittest.TestCase):
+    """Ensure configuration schema errors are surfaced correctly."""
+
     def setUp(self):
+        """Insert a dummy API key required by the orchestrator."""
         os.environ["OPENAI_API_KEY"] = "dummy"
 
     def tearDown(self):
+        """Clean up environment variable after each test."""
         del os.environ["OPENAI_API_KEY"]
 
     def test_missing_node_type_raises(self):
+        """Nodes without a type should trigger a validation error."""
         invalid_graph = {
             "nodes": [{"id": "a"}],
             "edges": []
@@ -23,6 +30,7 @@ class TestConfigSchema(unittest.TestCase):
             GraphOrchestrator(invalid_graph, FakeLLM(), {})
 
     def test_invalid_data_mapping_type(self):
+        """Edges with non-dict data_mapping should raise an error."""
         invalid_graph = {
             "nodes": [
                 {"id": "a", "type": "A"},


### PR DESCRIPTION
## Summary
- add missing module, class, and function docstrings across tests
- silence pylint warning for minimal DummyLLM in OpenAI API test
- document schema validation tests for orchestrator

## Testing
- `PYTHONPATH=. pytest tests/test_agent_integration.py tests/test_call_openai_api.py tests/test_config_schema.py`
- `pip install pylint` *(fails: Could not find a version that satisfies the requirement pylint)*

------
https://chatgpt.com/codex/tasks/task_e_68ae38f4bd8083318914d1c692dd458d