### PR TITLE
Add docstrings and optional reportlab handling in tests

### DIFF
--- a/tests/test_multi_doc_synthesizer_agent.py
+++ b/tests/test_multi_doc_synthesizer_agent.py
@@ -1,12 +1,19 @@
+"""Tests for :class:`MultiDocSynthesizerAgent`."""
+
 import os
 import unittest
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from agents.multi_doc_synthesizer_agent import MultiDocSynthesizerAgent
 from llm_fake import FakeLLM
 
-
 class TestMultiDocSynthesizerAgent(unittest.TestCase):
+    """Unit tests for the multi-document synthesizer agent."""
+
     def setUp(self):
+        """Set up test dependencies and environment."""
         os.environ["OPENAI_API_KEY"] = "dummy_key"
         self.app_config = {
             "system_variables": {"models": {}},
@@ -22,9 +29,11 @@ class TestMultiDocSynthesizerAgent(unittest.TestCase):
         )
 
     def tearDown(self):
+        """Clean up the environment variables."""
         del os.environ["OPENAI_API_KEY"]
 
     def test_synthesizes_valid_summaries(self):
+        """The agent combines valid summaries into a synthesis."""
         summaries = [
             {"summary": "First", "original_pdf_path": "doc1.pdf"},
             {"summary": "Second", "original_pdf_path": "doc2.pdf"},
@@ -35,6 +44,7 @@ class TestMultiDocSynthesizerAgent(unittest.TestCase):
         self.assertNotIn("error", result)
 
     def test_handles_upstream_error(self):
+        """The agent reports an upstream error."""
         result = self.agent.execute({"all_pdf_summaries_error": True, "error": "boom"})
         self.assertIn("error", result)
         self.assertEqual(result["error"], "Upstream error providing PDF summaries: boom")


### PR DESCRIPTION
## Summary
- add module, class, and method docstrings to orchestrator and multi-doc synthesizer tests
- conditionally import reportlab and skip tests when unavailable
- ensure tests can import project modules by appending root to path

## Testing
- `pytest tests/test_multi_doc_synthesizer_agent.py tests/test_orchestrator.py`
- `pylint tests/test_multi_doc_synthesizer_agent.py tests/test_orchestrator.py` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68ae39218fa08331a841576b621f6d24