### PR TITLE
Ensure workflow output files are never empty

### DIFF
--- a/multi_agent_llm_system.py
+++ b/multi_agent_llm_system.py
@@ -368,8 +368,8 @@ class GraphOrchestrator:
             if folder_path and os.path.exists(folder_path):
                 try:
                     with open(os.path.join(folder_path, filename), "w", encoding="utf-8") as f:
-                        if content is not None:
-                            f.write(str(content))
+                        text = str(content) if content not in [None, ""] else "No content generated."
+                        f.write(text)
                     log_status(
                         f"Saved '{filename}' to '{folder_path}'" + (" (empty)" if content in [None, ""] else "")
                     )
@@ -395,21 +395,20 @@ class GraphOrchestrator:
         key_ops = hypo_gen_node_out.get("key_opportunities")
         write_output_file("hypotheses", "key_research_opportunities.txt", key_ops)
         hypo_list = hypo_gen_node_out.get("hypotheses_list", [])
-        if hypo_list:
-            hypo_list_content = ""
-            # The structure of hypo_list can be a list of strings or dicts
-            for i, h_item in enumerate(hypo_list):
-                if isinstance(h_item, dict):
-                    hypo_list_content += f"{i + 1}. {h_item.get('hypothesis', 'N/A')}\n\n"
-                else:
-                    hypo_list_content += f"{i + 1}. {h_item}\n\n"
-            write_output_file("hypotheses", "hypotheses_list.txt", hypo_list_content.strip())
+        hypo_list_content = ""
+        # The structure of hypo_list can be a list of strings or dicts
+        for i, h_item in enumerate(hypo_list):
+            if isinstance(h_item, dict):
+                hypo_list_content += f"{i + 1}. {h_item.get('hypothesis', 'N/A')}\n\n"
+            else:
+                hypo_list_content += f"{i + 1}. {h_item}\n\n"
+        write_output_file("hypotheses", "hypotheses_list.txt", hypo_list_content.strip())
         exp_designs_list = outputs_history.get("experiment_designer", {}).get("experiment_designs_list", [])
         exp_path = project_output_paths.get("experiments")
         if exp_designs_list and exp_path and os.path.exists(exp_path):
             for i, design_info in enumerate(exp_designs_list):
                 hypo = design_info.get("hypothesis_processed", f"Hypothesis_N/A_{i + 1}")
-                design = design_info.get("experiment_design", "")
+                design = design_info.get("experiment_design", "") or "No experiment design generated."
                 err = design_info.get("error")
                 safe_hypo_part = "".join(c if c.isalnum() else "_" for c in str(hypo)[:50]).strip('_')
                 if not safe_hypo_part:

--- a/tests/test_output_placeholders.py
+++ b/tests/test_output_placeholders.py
@@ -1,0 +1,37 @@
+from multi_agent_llm_system import GraphOrchestrator
+from llm_fake import FakeLLM
+
+def test_save_consolidated_outputs_writes_placeholders(tmp_path):
+    app_config = {
+        "system_variables": {
+            "output_project_synthesis_folder_name": "project_synthesis",
+            "output_project_hypotheses_folder_name": "project_hypotheses",
+            "output_project_experiments_folder_name": "project_experiments",
+        },
+        "graph_definition": {"nodes": [], "edges": []},
+    }
+    orchestrator = GraphOrchestrator(app_config["graph_definition"], FakeLLM(app_config), app_config)
+    outputs_history = {
+        "multi_doc_synthesizer": {"multi_doc_synthesis_output": ""},
+        "knowledge_integrator": {"integrated_knowledge_brief": ""},
+        "hypothesis_generator": {
+            "hypotheses_output_blob": "",
+            "hypotheses_list": [],
+            "key_opportunities": "",
+        },
+        "experiment_designer": {
+            "experiment_designs_list": [
+                {"hypothesis_processed": "Hypothesis1", "experiment_design": ""}
+            ]
+        },
+    }
+    orchestrator._save_consolidated_outputs(outputs_history, str(tmp_path))
+    synthesis_file = tmp_path / "project_synthesis" / "multi_document_synthesis.txt"
+    assert synthesis_file.read_text(encoding="utf-8") == "No content generated."
+    hypotheses_file = tmp_path / "project_hypotheses" / "hypotheses_list.txt"
+    assert hypotheses_file.read_text(encoding="utf-8") == "No content generated."
+    exp_dir = tmp_path / "project_experiments"
+    exp_files = list(exp_dir.iterdir())
+    assert exp_files, "Experiment design file not created"
+    exp_content = exp_files[0].read_text(encoding="utf-8")
+    assert "No experiment design generated." in exp_content


### PR DESCRIPTION
## Summary
- Write `No content generated.` placeholder when saving empty synthesis or hypothesis outputs
- Fill missing experiment designs with a placeholder message
- Add regression test to confirm placeholder files are created for empty outputs

## Testing
- `pytest tests/test_output_placeholders.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b44080903c833187b5967f0aced1ab