### PR TITLE
Add WebResearcherAgent and unit test

### DIFF
--- a/agents/web_researcher_agent.py
+++ b/agents/web_researcher_agent.py
@@ -1,0 +1,46 @@
+"""Agent for performing simple web research summarization."""
+
+from llm import LLMError
+from utils import log_status
+
+from .base_agent import Agent
+from .registry import register_agent
+
+
+@register_agent("WebResearcherAgent")
+class WebResearcherAgent(Agent):
+    """Use an LLM to generate a brief web research summary."""
+
+    def execute(self, inputs: dict) -> dict:
+        """Generate a web research summary using the provided context."""
+        current_system_message = self.get_formatted_system_message()
+        if current_system_message.startswith("ERROR:"):
+            return {"web_summary": "", "error": current_system_message}
+
+        cross_doc = inputs.get("cross_document_understanding")
+        if not cross_doc:
+            log_status(
+                f"[{self.agent_id}] INFO: No 'cross_document_understanding' provided."
+            )
+            return {"web_summary": ""}
+
+        prompt = (
+            "Using the following cross-document understanding, perform brief web-style "
+            "research and provide a concise summary with any additional relevant context:\n\n"
+            f"{cross_doc}"
+        )
+        temperature = float(self.config_params.get("temperature", 0.6))
+        try:
+            summary = self.llm.complete(
+                system=current_system_message,
+                prompt=prompt,
+                model=self.model_name,
+                temperature=temperature,
+            )
+        except LLMError as e:  # pragma: no cover - LLM errors are rare
+            return {"web_summary": "", "error": str(e)}
+
+        log_status(
+            f"[{self.agent_id}] INFO: Web research summary generated (length={len(summary)})."
+        )
+        return {"web_summary": summary}

--- a/tests/test_web_researcher_agent.py
+++ b/tests/test_web_researcher_agent.py
@@ -1,0 +1,19 @@
+import pytest
+
+from agents.web_researcher_agent import WebResearcherAgent
+from llm_fake import FakeLLM
+
+
+def test_web_researcher_produces_summary():
+    app_config = {
+        "agent_prompts": {"web_researcher_sm": "You are a web researcher."}
+    }
+    agent = WebResearcherAgent(
+        agent_id="web_researcher",
+        agent_type="WebResearcherAgent",
+        config_params={"model_key": "pdf_summarizer", "system_message_key": "web_researcher_sm"},
+        llm=FakeLLM(app_config=app_config),
+        app_config=app_config,
+    )
+    result = agent.execute({"cross_document_understanding": "Some findings"})
+    assert result["web_summary"], "Web research summary should not be empty"


### PR DESCRIPTION
## Summary
- add WebResearcherAgent for web research summarization to finish pipeline
- test WebResearcherAgent produces non-empty summary

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b48c46be548331a7f6e15e685dd3ac