### PR TITLE
Add CLI entry point and adaptive option

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,9 +111,21 @@ python gui.py
 
 #### Command-Line Interface (CLI)
 
-For testing and automation, you can run the system directly from the command line. The `cli_test.py` script provides a template for this.
+Run MACS directly from the terminal using `cli.py`:
 
-1.  **Configure for CLI:** The script uses `config_cli_test_integrated.json`. If this file doesn't exist, the script will create a template for you. **You must edit this file to add a valid OpenAI API key.**
+```bash
+python cli.py --config config.json --pdf-dir path/to/pdfs --experimental-data path/to/data.txt --out-dir project_output
+```
+
+Add `--adaptive` to enable the adaptive orchestration cycle:
+
+```bash
+python cli.py --config config.json --pdf-dir path/to/pdfs --experimental-data path/to/data.txt --out-dir project_output --adaptive
+```
+
+For a self-contained test harness, the repository also includes `cli_test.py`.
+
+1.  **Configure for CLI testing:** The script uses `config_cli_test_integrated.json`. If this file doesn't exist, the script will create a template for you. **You must edit this file to add a valid OpenAI API key.**
 2.  **Run the test script:**
     ```bash
     python cli_test.py

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Command line interface for running the MACS workflow."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from typing import List
+
+from multi_agent_llm_system import run_project_orchestration
+from utils import load_app_config
+
+
+def _collect_pdf_paths(directories: List[str]) -> List[str]:
+    """Gather all PDF files from the provided directories."""
+    pdf_paths: List[str] = []
+    for directory in directories:
+        if not os.path.isdir(directory):
+            continue
+        for root, _dirs, files in os.walk(directory):
+            for name in files:
+                if name.lower().endswith(".pdf"):
+                    pdf_paths.append(os.path.join(root, name))
+    return pdf_paths
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run MACS project orchestration")
+    parser.add_argument(
+        "--config",
+        type=str,
+        default="config.json",
+        help="Path to configuration file.",
+    )
+    parser.add_argument(
+        "--pdf-dir",
+        nargs="+",
+        required=True,
+        help="One or more directories containing PDF files.",
+    )
+    parser.add_argument(
+        "--experimental-data",
+        type=str,
+        default="",
+        help="Optional path to experimental data file.",
+    )
+    parser.add_argument(
+        "--out-dir",
+        required=True,
+        help="Directory where outputs will be written.",
+    )
+    parser.add_argument(
+        "--adaptive",
+        action="store_true",
+        help="Run adaptive orchestration cycle instead of single pass.",
+    )
+    args = parser.parse_args()
+
+    pdf_file_paths = _collect_pdf_paths(args.pdf_dir)
+    if not pdf_file_paths:
+        print("No PDF files found in specified directories.")
+        return
+
+    if args.adaptive:
+        from adaptive.adaptive_graph_runner import adaptive_cycle
+        from adaptive.evaluation import evaluate_target_function
+
+        inputs = {
+            "initial_inputs": {
+                "all_pdf_paths": pdf_file_paths,
+                "experimental_data_file_path": args.experimental_data,
+            },
+            "project_base_output_dir": args.out_dir,
+        }
+        adaptive_cycle(
+            config_path=args.config,
+            inputs=inputs,
+            evaluate_fn=evaluate_target_function,
+            threshold=1.0,
+            max_steps=5,
+        )
+        return
+
+    app_config = load_app_config(config_path=args.config)
+    if not app_config:
+        print(f"Failed to load configuration from '{args.config}'.")
+        return
+
+    run_project_orchestration(
+        pdf_file_paths=pdf_file_paths,
+        experimental_data_path=args.experimental_data,
+        project_base_output_dir=args.out_dir,
+        status_update_callback=print,
+        app_config=app_config,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add new `cli.py` script for running MACS from the command line
- support `--adaptive` flag delegating to `adaptive_cycle`
- document CLI usage and adaptive option in README

## Testing
- `pytest -q`
- `python cli.py -h`


------
https://chatgpt.com/codex/tasks/task_e_68b4b01ff1408331a8ade7f235490362