### PR TITLE
feat: add plugin listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,16 @@ PLUGIN = AgentPlugin(
 )
 ```
 
-`load_plugins()` automatically discovers modules in this folder, registers compatible agents, and checks the `macs_version` field for compatibility.
+`load_plugins()` automatically discovers modules in this folder, registers compatible agents, and checks the `macs_version` field for compatibility.  
+Additionally, plugins can be distributed as Python packages that expose a
+`macs.plugins` entry point. After installing such a package with `pip`, the
+plugin will be detected automatically.
+
+To see all registered agents and plugins, run:
+
+```bash
+python cli.py --list-plugins
+```
 
 For a light-hearted example, check out `agent_plugins/skynet_agent.py`, which playfully references Skynet becoming self-aware.
 

--- a/cli.py
+++ b/cli.py
@@ -35,7 +35,6 @@ def main() -> None:
     parser.add_argument(
         "--pdf-dir",
         nargs="+",
-        required=True,
         help="One or more directories containing PDF files.",
     )
     parser.add_argument(
@@ -46,7 +45,6 @@ def main() -> None:
     )
     parser.add_argument(
         "--out-dir",
-        required=True,
         help="Directory where outputs will be written.",
     )
     parser.add_argument(
@@ -54,7 +52,26 @@ def main() -> None:
         action="store_true",
         help="Run adaptive orchestration cycle instead of single pass.",
     )
+    parser.add_argument(
+        "--list-plugins",
+        action="store_true",
+        help="List available agents and plugins and exit.",
+    )
     args = parser.parse_args()
+
+    if args.list_plugins:
+        from agents.registry import load_agents, load_plugins, list_plugins
+
+        load_agents()
+        load_plugins()
+        for info in list_plugins():
+            author = f" by {info['author']}" if info["author"] else ""
+            print(f"{info['name']} ({info['version']}){author}")
+        return
+
+    if not args.pdf_dir or not args.out_dir:
+        print("--pdf-dir and --out-dir are required unless --list-plugins is provided.")
+        return
 
     pdf_file_paths = _collect_pdf_paths(args.pdf_dir)
     if not pdf_file_paths:


### PR DESCRIPTION
## Summary
- discover agent plugins via `importlib.metadata.entry_points`
- list registered agents with new `list_plugins` helper
- expose `--list-plugins` flag in CLI and document plugin installation

## Testing
- `pytest`
- `flake8 agents/registry.py cli.py tests/test_plugin_interface.py` *(failed: command not found or installation blocked)*


------
https://chatgpt.com/codex/tasks/task_e_68b4b16b7d4c8331bf171fa6ceca1b78