### PR TITLE
Add evaluation plugin system

### DIFF
--- a/adaptive/evaluation.py
+++ b/adaptive/evaluation.py
@@ -1,15 +1,72 @@
-"""Helper functions for evaluating adaptive graph outputs.
+"""Helper functions and plugin interfaces for adaptive graph evaluation.
 
-This module exposes :func:`evaluate_target_function`, a small utility used by
-the adaptive workflow to decide whether further mutation of the graph is
-required based on the score returned from a run.
+This module exposes :class:`EvaluationPlugin` used for pluggable evaluation
+strategies and :func:`evaluate_target_function`, a small utility used by the
+adaptive workflow to decide whether further mutation of the graph is required
+based on the score returned from a run.
 """
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+import importlib
+from importlib import metadata
+from typing import Any, Dict, List, Optional, Protocol, Sequence
 
 from .mutation import mutate_graph_definition
+
+
+class EvaluationPlugin(Protocol):
+    """Protocol for evaluation plugins.
+
+    Evaluation plugins analyse the outputs of a graph run and return a numeric
+    score. The adaptive runner aggregates scores from all loaded plugins to
+    decide whether further mutation is required.
+    """
+
+    def evaluate(
+        self,
+        outputs: Dict[str, Any],
+        graph_def: Dict[str, Any],
+        threshold: float,
+        step: int,
+    ) -> float:
+        """Return a score for the current step."""
+
+
+def load_evaluation_plugins(paths: Optional[Sequence[str]] = None) -> List[EvaluationPlugin]:
+    """Load evaluation plugins from module paths or entry points.
+
+    Parameters
+    ----------
+    paths:
+        Optional sequence of ``"module:Class"`` strings pointing to evaluator
+        classes defined in configuration files.
+    """
+
+    evaluators: List[EvaluationPlugin] = []
+
+    for path in paths or []:
+        module_name, class_name = path.split(":")
+        module = importlib.import_module(module_name)
+        cls = getattr(module, class_name)
+        evaluators.append(cls())
+
+    try:
+        entry_points = metadata.entry_points()
+        if hasattr(entry_points, "select"):
+            eval_eps = entry_points.select(group="macs.evaluators")
+        else:  # pragma: no cover - deprecated API
+            eval_eps = entry_points.get("macs.evaluators", [])
+        for ep in eval_eps:
+            try:
+                cls = ep.load()
+                evaluators.append(cls())
+            except Exception:  # pragma: no cover - defensive
+                continue
+    except Exception:  # pragma: no cover - defensive
+        pass
+
+    return evaluators
 
 
 def evaluate_target_function(

--- a/adaptive/rerun_after_evaluation.py
+++ b/adaptive/rerun_after_evaluation.py
@@ -12,7 +12,6 @@ import argparse
 from typing import Any, Dict
 
 from .adaptive_graph_runner import adaptive_cycle
-from .evaluation import evaluate_target_function
 from .json_utils import load_json, save_json
 
 
@@ -48,7 +47,6 @@ def rerun_with_evaluation(
     adaptive_cycle(
         config_path,
         run_inputs,
-        evaluate_target_function,
         threshold=threshold,
         max_steps=max_steps,
     )

--- a/agent_plugins/sample_evaluator.py
+++ b/agent_plugins/sample_evaluator.py
@@ -1,0 +1,20 @@
+"""Example evaluation plugin for tests and documentation."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from adaptive.evaluation import EvaluationPlugin
+
+
+class SampleEvaluator(EvaluationPlugin):
+    """Simple evaluator that reads a ``score`` value from outputs."""
+
+    def evaluate(
+        self,
+        outputs: Dict[str, Any],
+        graph_def: Dict[str, Any],
+        threshold: float,
+        step: int,
+    ) -> float:
+        return float(outputs.get("score", 0.0))

--- a/cli.py
+++ b/cli.py
@@ -80,7 +80,6 @@ def main() -> None:
 
     if args.adaptive:
         from adaptive.adaptive_graph_runner import adaptive_cycle
-        from adaptive.evaluation import evaluate_target_function
 
         inputs = {
             "initial_inputs": {
@@ -92,7 +91,6 @@ def main() -> None:
         adaptive_cycle(
             config_path=args.config,
             inputs=inputs,
-            evaluate_fn=evaluate_target_function,
             threshold=1.0,
             max_steps=5,
         )

--- a/docs/DEVELOPMENT_GUIDE.md
+++ b/docs/DEVELOPMENT_GUIDE.md
@@ -108,6 +108,16 @@ To experiment with adaptive runs, execute:
 python adaptive/adaptive_graph_runner.py --config config.json
 ```
 
+### Evaluation Plugins
+
+Adaptive runs can use custom evaluation plugins to score graph outputs. An
+evaluation plugin implements an ``evaluate(outputs, graph_def, threshold, step)``
+method and returns a numeric score. Plugins can be referenced in
+``config.json`` using ``evaluation_plugins`` with entries like
+``"agent_plugins.sample_evaluator:SampleEvaluator"`` or exposed via the
+``macs.evaluators`` entry point. When multiple plugins are provided, their
+scores are averaged to decide whether the graph should mutate further.
+
 ---
 
 ## 8. Coding Style

--- a/tests/test_adaptive_evaluation.py
+++ b/tests/test_adaptive_evaluation.py
@@ -1,0 +1,88 @@
+"""Tests for evaluation plugin loading and adaptive cycle aggregation."""
+
+import json
+import importlib.metadata as md
+
+import pytest
+
+from adaptive.evaluation import load_evaluation_plugins
+from adaptive import adaptive_graph_runner
+
+
+def test_load_evaluation_plugins_from_config_and_entry_points(monkeypatch):
+    """Evaluators can be loaded from config paths and entry points."""
+
+    class DummyEP:
+        name = "ep_eval"
+
+        def load(self):
+            class EPEval:
+                def evaluate(self, outputs, graph_def, threshold, step):
+                    return 0.6
+
+            return EPEval
+
+    def fake_entry_points():
+        return {"macs.evaluators": [DummyEP()]}
+
+    monkeypatch.setattr(md, "entry_points", fake_entry_points)
+
+    evaluators = load_evaluation_plugins(
+        ["agent_plugins.sample_evaluator:SampleEvaluator"]
+    )
+    assert len(evaluators) == 2
+    scores = [ev.evaluate({"score": 0.4}, {}, 0.5, 1) for ev in evaluators]
+    assert pytest.approx(sum(scores) / len(scores)) == 0.5
+
+
+def test_adaptive_cycle_aggregates_scores(monkeypatch, tmp_path):
+    """Adaptive cycle averages scores from multiple evaluators."""
+
+    class DummyEP:
+        name = "ep_eval"
+
+        def load(self):
+            class EpEval:
+                def evaluate(self, outputs, graph_def, threshold, step):
+                    return 0.6
+
+            return EpEval
+
+    monkeypatch.setattr(
+        md, "entry_points", lambda: {"macs.evaluators": [DummyEP()]}
+    )
+
+    config = {
+        "graph_definition": {},
+        "evaluation_plugins": ["agent_plugins.sample_evaluator:SampleEvaluator"],
+    }
+    config_path = tmp_path / "cfg.json"
+    config_path.write_text(json.dumps(config))
+    inputs = {"initial_inputs": {}, "project_base_output_dir": "."}
+
+    class DummyOrchestrator:
+        def __init__(self, graph_def, llm, config):
+            pass
+
+        def run(self, initial_inputs, project_base_output_dir):
+            return {"score": 0.4}
+
+    monkeypatch.setattr(
+        adaptive_graph_runner, "GraphOrchestrator", DummyOrchestrator
+    )
+    monkeypatch.setattr(
+        adaptive_graph_runner, "_create_llm_client", lambda cfg: object()
+    )
+
+    mutated = {"called": False}
+
+    def fake_mutate(graph_def, step):
+        mutated["called"] = True
+        return {"step": step}
+
+    monkeypatch.setattr(adaptive_graph_runner, "mutate_graph_definition", fake_mutate)
+
+    adaptive_graph_runner.adaptive_cycle(
+        str(config_path), inputs, threshold=0.5, max_steps=1
+    )
+    assert not mutated["called"]

--- a/tests/test_rerun_after_evaluation.py
+++ b/tests/test_rerun_after_evaluation.py
@@ -20,8 +20,8 @@ def test_rerun_with_evaluation(monkeypatch, tmp_path):
     """Validate rerunning experiments using previous evaluation data."""
     calls = {}
 
-    def fake_cycle(config, inputs, eval_fn, threshold, max_steps):
-        calls["args"] = (config, inputs, eval_fn, threshold, max_steps)
+    def fake_cycle(config, inputs, threshold, max_steps):
+        calls["args"] = (config, inputs, threshold, max_steps)
 
     monkeypatch.setattr(rerun_after_evaluation, "adaptive_cycle", fake_cycle)
 
@@ -50,6 +50,5 @@ def test_rerun_with_evaluation(monkeypatch, tmp_path):
     args = calls["args"]
     assert args[0] == str(config_path)
     assert args[1] == {"initial_inputs": {}, "project_base_output_dir": "."}
-    assert callable(args[2])
-    assert args[3] == 0.8
-    assert args[4] == 2
+    assert args[2] == 0.8
+    assert args[3] == 2


### PR DESCRIPTION
## Summary
- define `EvaluationPlugin` protocol and helper to load evaluators
- allow `adaptive_cycle` to load multiple evaluation plugins and aggregate scores
- document and test evaluation plugin usage, including a sample plugin

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4bbdb46f883319ff91657ebaed11c