### PR TITLE
docs: clarify run history usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,9 +177,12 @@ stored in `storage/run_history.jsonl`, and the full configuration is written to
 to inspect past runs or to rerun a previous configuration:
 
 ```python
-from storage.run_history import get_run
-record = get_run("<run_id>")
+from storage.run_history import list_runs, get_run
+
+runs = list_runs()
+record = get_run(runs[-1]["run_id"])
 config = record["config"]
+prompt_ids = record.get("prompt_ids")
 # pass `config` back into `run_project_orchestration` to reproduce the run
 ```
 

--- a/docs/run_history.md
+++ b/docs/run_history.md
@@ -2,9 +2,10 @@
 
 Every call to `run_project_orchestration` is assigned a unique `run_id`. A
 record of the run is appended to `storage/run_history.jsonl`, while the full
-configuration used for that run is written to a separate JSON file. This
-allows past runs to be inspected or replayed without turning the history log
-into a large database of configs.
+configuration used for that run is written to a separate JSON file. The
+`run_id` is also returned in the orchestration results so it can be captured
+immediately by calling code. This setup allows past runs to be inspected or
+replayed without turning the history log into a large database of configs.
 
 ## Recording Runs
 
@@ -36,6 +37,7 @@ from storage.run_history import get_run, list_runs
 all_runs = list_runs()
 last_run = get_run(all_runs[-1]["run_id"])
 config = last_run["config"]
+prompt_ids = last_run.get("prompt_ids")
 ```
 
 The retrieved `config` can be supplied directly to `run_project_orchestration`


### PR DESCRIPTION
## Summary
- Document `list_runs` and `get_run` helpers for recovering past run configs
- Note that orchestration returns `run_id` and show how to inspect prompt IDs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5a2e9b55883318ca8b4b37359baa8