### PR TITLE
Expand run history utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,9 @@ runs = list_runs()
 record = get_run(runs[-1]["run_id"])
 config = record["config"]
 prompt_ids = record.get("prompt_ids")
+
+# alternatively load every record with its config
+runs_with_config = list_runs(include_config=True)
 # pass `config` back into `run_project_orchestration` to reproduce the run
 ```
 

--- a/docs/run_history.md
+++ b/docs/run_history.md
@@ -38,6 +38,9 @@ all_runs = list_runs()
 last_run = get_run(all_runs[-1]["run_id"])
 config = last_run["config"]
 prompt_ids = last_run.get("prompt_ids")
+
+# or load configurations for all runs in one step
+all_runs_with_config = list_runs(include_config=True)
 ```
 
 The retrieved `config` can be supplied directly to `run_project_orchestration`

--- a/storage/run_history.py
+++ b/storage/run_history.py
@@ -47,7 +47,20 @@ def save_run(run_id: str, app_config: Dict[str, Any], extra: Optional[Dict[str, 
     log_status(f"[RunHistory] INFO: Recorded run {run_id}")
 
 def get_run(run_id: str) -> Optional[Dict[str, Any]]:
-    """Retrieve a run record by its identifier."""
+    """Retrieve a run record and its full configuration by ``run_id``.
+
+    Parameters
+    ----------
+    run_id: str
+        Identifier returned by :func:`save_run`.
+
+    Returns
+    -------
+    Optional[Dict[str, Any]]
+        The stored record with the ``config`` key populated with the
+        serialized application configuration, or ``None`` if the run is
+        unknown.
+    """
     if not os.path.exists(RUN_HISTORY_PATH):
         return None
     with open(RUN_HISTORY_PATH, "r", encoding="utf-8") as f:
@@ -67,14 +80,32 @@ def get_run(run_id: str) -> Optional[Dict[str, Any]]:
                 return rec
     return None
 
-def list_runs() -> List[Dict[str, Any]]:
-    """Return all stored run records."""
+def list_runs(include_config: bool = False) -> List[Dict[str, Any]]:
+    """Return all stored run records.
+
+    Parameters
+    ----------
+    include_config: bool, optional
+        If ``True`` the full configuration for each run is loaded and
+        attached to the record in a ``config`` key. Defaults to ``False``
+        to keep listing lightweight.
+    """
     if not os.path.exists(RUN_HISTORY_PATH):
         return []
     records: List[Dict[str, Any]] = []
     with open(RUN_HISTORY_PATH, "r", encoding="utf-8") as f:
         for line in f:
             line = line.strip()
-            if line:
-                records.append(json.loads(line))
+            if not line:
+                continue
+            rec = json.loads(line)
+            if include_config:
+                cfg_rel_path = rec.get("config_path")
+                if cfg_rel_path:
+                    cfg_abs_path = os.path.join(os.path.dirname(RUN_HISTORY_PATH), cfg_rel_path)
+                    if os.path.exists(cfg_abs_path):
+                        with open(cfg_abs_path, "r", encoding="utf-8") as cf:
+                            rec["config"] = json.load(cf)
+                    rec["config_path"] = cfg_abs_path
+            records.append(rec)
     return records


### PR DESCRIPTION
## Summary
- document run history workflow and examples
- expose run retrieval helpers that optionally load stored configs
- log a unique run identifier and record metadata before project execution

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5a46b265883319701197d74d57349