### PR TITLE
refactor: adapt to Responses API output schema

### DIFF
--- a/llm_openai.py
+++ b/llm_openai.py
@@ -123,14 +123,10 @@ class OpenAILLM(LLMClient):
             self.last_token_usage = usage
             self.total_tokens_used += usage
 
-            outputs = []
-            for item in getattr(response, "output", []) or []:
-                for content in getattr(item, "content", []) or []:
-                    text_val = getattr(getattr(content, "text", None), "value", None)
-                    if text_val:
-                        outputs.append(text_val)
-
-            if not outputs:
+            output_items = getattr(response, "output", None)
+            try:
+                result = output_items[0].content[0].text.strip()  # type: ignore[index]
+            except (TypeError, AttributeError, IndexError):
                 log_status(
                     f"[LLM] LLM_CALL_ERROR: Model='{chosen_model}' response has no textual output."
                 )
@@ -138,7 +134,6 @@ class OpenAILLM(LLMClient):
                     f"OpenAI API response had no textual output for model {chosen_model}."
                 )
 
-            result = "".join(outputs).strip()
             snippet = result[:150].replace("\n", " ")
             log_status(
                 f"[LLM] LLM_CALL_SUCCESS: Model='{chosen_model}', Response(start): '{snippet}...'"

--- a/tests/test_call_openai_api.py
+++ b/tests/test_call_openai_api.py
@@ -70,11 +70,8 @@ def test_call_openai_api_omits_temperature_for_gpt5(monkeypatch):
         def create(self, **kwargs):  # noqa: D401
             captured["temperature"] = kwargs.get("temperature")
 
-            class Text:  # pylint: disable=too-few-public-methods
-                value = "hi"
-
             class Content:  # pylint: disable=too-few-public-methods
-                text = Text()
+                text = "hi"
 
             class Output:  # pylint: disable=too-few-public-methods
                 content = [Content()]


### PR DESCRIPTION
## Summary
- switch OpenAI client to read text from `response.output[0].content[0].text`
- adjust tests for updated response structure

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5aa579d888331bd7de23b13535a1c