### PR TITLE
Document Responses API migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,13 @@
    pip install -r requirements.txt
    ```
 
-   *Dependencies include PyQt6, openai, PyPDF2, reportlab, etc.*
+   *Dependencies include PyQt6, openai>=1.x, PyPDF2, reportlab, etc.*
 
 3. **Configure OpenAI API Key:**
    - Add your API key to the `openai_api_key` field in `config.json`.
+4. **Prompts & Conversations (optional):**
+   - The project uses the OpenAI Responses API. If migrating from the Assistants API, replace any `OPENAI_ASSISTANT_ID`/`OPENAI_THREAD_ID` environment variables with `OPENAI_PROMPT_ID`/`OPENAI_CONVERSATION_ID`.
+   - Prompt IDs can also be supplied in `system_variables.prompt_ids` inside `config.json`.
 
 ### Running the Application
 
@@ -123,6 +126,28 @@ Add `--adaptive` to enable the adaptive orchestration cycle:
 ```bash
 python cli.py --config config.json --pdf-dir path/to/pdfs --experimental-data path/to/data.txt --out-dir project_output --adaptive
 ```
+
+### Prompts, Conversations, and Responses
+
+The OpenAI Responses API replaces Assistants and Threads. A basic call looks like:
+
+```python
+from openai import OpenAI
+
+client = OpenAI()
+response = client.responses.create(
+    model="gpt-4.1-mini",
+    input=[
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Write a haiku about MACS."},
+    ],
+    prompt_id="pr_123",
+    conversation_id="cv_456",
+)
+print(response.output_text)
+```
+
+See [docs/RESPONSES_API_MIGRATION.md](docs/RESPONSES_API_MIGRATION.md) for more details.
 
 For a self-contained test harness, the repository also includes `cli_test.py`.
 

--- a/docs/DEVELOPMENT_GUIDE.md
+++ b/docs/DEVELOPMENT_GUIDE.md
@@ -30,7 +30,7 @@ When adding new modules, strive to keep the hierarchy shallow and file names des
    ```bash
    pip install -r requirements.txt
    ```
-3. **LLM Credentials** – Some agents rely on external LLM providers such as OpenAI. Set environment variables (e.g. `OPENAI_API_KEY`) before running tests or the CLI.
+3. **LLM Credentials** – Some agents rely on external LLM providers such as OpenAI. Set environment variables (e.g. `OPENAI_API_KEY`, `OPENAI_PROMPT_ID`, `OPENAI_CONVERSATION_ID`) before running tests or the CLI.
 4. **Optional Tools** – For development you may also install linters like `ruff` or formatters like `black`.
 
 ---

--- a/docs/RESPONSES_API_MIGRATION.md
+++ b/docs/RESPONSES_API_MIGRATION.md
@@ -1,0 +1,45 @@
+# Migrating to the OpenAI Responses API
+
+The OpenAI Responses API replaces the earlier Assistants and Threads APIs. Prompts and conversations now identify
+reusable instructions and ongoing sessions.
+
+## Environment Variables
+
+If you previously used the Assistants API, rename any environment variables as follows:
+
+- `OPENAI_ASSISTANT_ID` → `OPENAI_PROMPT_ID`
+- `OPENAI_THREAD_ID` → `OPENAI_CONVERSATION_ID`
+
+`OPENAI_PROMPT_ID` and `OPENAI_CONVERSATION_ID` may be supplied directly as environment variables or stored in
+`system_variables.prompt_ids` inside `config.json`.
+
+Example configuration snippet:
+
+```json
+{
+  "system_variables": {
+    "openai_api_key": "sk-...",
+    "prompt_ids": ["pr_123"]
+  }
+}
+```
+
+## Example Usage
+
+```python
+from openai import OpenAI
+
+client = OpenAI()
+response = client.responses.create(
+    model="gpt-4.1-mini",
+    input=[
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Say hello"},
+    ],
+    prompt_id="pr_123",
+    conversation_id="cv_456",
+)
+print(response.output_text)
+```
+
+This call returns a response object whose `output_text` contains the model's reply.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 fastapi
 uvicorn
 python-dotenv
-openai
+openai>=1.0.0
 langchain
 langchain-openai
 langchain-community


### PR DESCRIPTION
## Summary
- pin `openai` to 1.x for Responses API support
- document migration to prompts/conversations with usage example
- mention new `OPENAI_PROMPT_ID` and `OPENAI_CONVERSATION_ID` variables

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5ac730bcc83318f21a8d509a9a51f