### PR TITLE
Ensure FakeLLM caching doesn't inflate token counts and test OpenAI timeout handling

### DIFF
--- a/llm_fake.py
+++ b/llm_fake.py
@@ -53,8 +53,7 @@ class FakeLLM:
         key = self._cache.make_key(model, system, prompt, temperature)
         cached = self._cache.get(key)
         if cached is not None:
-            self.last_token_usage = len(prompt.split())
-            self.total_tokens_used += self.last_token_usage
+            self.last_token_usage = 0
             return cached
         result = self.get_response(system, prompt, model, temperature)
         self._cache.set(key, result)

--- a/tests/test_llm_clients.py
+++ b/tests/test_llm_clients.py
@@ -1,0 +1,33 @@
+import pytest
+
+from llm_fake import FakeLLM
+from llm_openai import APITimeoutError, OpenAILLM
+from llm import LLMError
+import llm_openai
+
+
+def test_fake_llm_uses_cache_without_incrementing_tokens():
+    """Calling FakeLLM with the same prompt twice should use cache."""
+    llm = FakeLLM()
+    first = llm.complete("system", "hello world", "gpt-3")
+    tokens_after_first = llm.get_total_tokens_used()
+    second = llm.complete("system", "hello world", "gpt-3")
+    assert second == first
+    assert llm.get_last_token_usage() == 0
+    assert llm.get_total_tokens_used() == tokens_after_first
+
+
+def test_openai_llm_wraps_timeout_error(monkeypatch):
+    """OpenAILLM.complete should wrap APITimeoutError in LLMError."""
+    class TimeoutOpenAI:
+        def __init__(self, *args, **kwargs):
+            self.responses = self
+
+        def create(self, **kwargs):  # pylint: disable=unused-argument
+            raise APITimeoutError("timeout")
+
+    monkeypatch.setattr(llm_openai, "OpenAI", TimeoutOpenAI)
+    llm = OpenAILLM({}, api_key="test-key")
+
+    with pytest.raises(LLMError):
+        llm.complete(system="sys", prompt="hi", model="gpt-3")


### PR DESCRIPTION
## Summary
- Prevent `FakeLLM` from incrementing token counts when returning cached responses
- Add tests covering `FakeLLM` caching behavior and OpenAI timeout error wrapping

## Testing
- `pytest`
- `flake8 llm_fake.py tests/test_llm_clients.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b5a90244833183c90032f9cba5bb