### PR TITLE
Handle missing dependencies in KnowledgeIntegratorAgent

### DIFF
--- a/agents/knowledge_integrator_agent.py
+++ b/agents/knowledge_integrator_agent.py
@@ -25,6 +25,21 @@ class KnowledgeIntegratorAgent(Agent):
         experimental_data_summary = inputs.get(
             "experimental_data_summary", "N/A (No experimental data provided or error upstream.)"
         )
+        deep_research_summary = inputs.get(
+            "deep_research_summary", "N/A (No deep research summary provided or error upstream.)"
+        )
+        long_term_memory = inputs.get("long_term_memory")
+
+        missing_dependencies = []
+        if inputs.get("deep_research_summary_error"):
+            missing_dependencies.append("deep_research_summary")
+        if long_term_memory is None:
+            missing_dependencies.append("long_term_memory")
+        if missing_dependencies:
+            return {
+                "integrated_knowledge_brief": "",
+                "error": "Missing required dependencies: " + ", ".join(missing_dependencies),
+            }
 
         # Check for upstream errors and prepend to content if necessary
         if inputs.get("multi_doc_synthesis_error"):

--- a/tests/test_knowledge_integrator_agent.py
+++ b/tests/test_knowledge_integrator_agent.py
@@ -32,6 +32,8 @@ class TestKnowledgeIntegratorAgent(unittest.TestCase):
             "multi_doc_synthesis": "docs",
             "web_research_summary": "web",
             "experimental_data_summary": "data",
+            "deep_research_summary": "deep",
+            "long_term_memory": "memory",
         }
         result = self.agent.execute(inputs)
         self.assertIn("integrated_knowledge_brief", result)
@@ -45,11 +47,21 @@ class TestKnowledgeIntegratorAgent(unittest.TestCase):
             "web_research_summary_error": True,
             "experimental_data_summary_error": True,
             "error": "fail",
+            "deep_research_summary": "deep",
+            "long_term_memory": "memory",
         }
         result = self.agent.execute(inputs)
         self.assertIn("integrated_knowledge_brief", result)
         self.assertEqual(result["integrated_knowledge_brief"], "[FAKE] ok")
         self.assertNotIn("error", result)
+
+    def test_reports_missing_dependencies(self):
+        """Agent reports missing mandatory dependency inputs."""
+        result = self.agent.execute({"deep_research_summary_error": True})
+        self.assertIn("error", result)
+        self.assertIn("deep_research_summary", result["error"])
+        self.assertIn("long_term_memory", result["error"])
+        self.assertEqual(result["integrated_knowledge_brief"], "")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- ensure KnowledgeIntegratorAgent validates deep research summary and long-term memory inputs
- expand KnowledgeIntegratorAgent tests to cover missing dependency errors

## Testing
- `python3 -m unittest tests.test_knowledge_integrator_agent -v` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68b5b712325c8331ba6936e713772869