### PR TITLE
Highlight active nodes and track token usage

### DIFF
--- a/llm.py
+++ b/llm.py
@@ -45,6 +45,14 @@ class LLMClient(Protocol):
         """Returns a cached embedding client if available."""
         raise NotImplementedError
 
+    def get_last_token_usage(self) -> int:
+        """Return the number of tokens used in the most recent completion call."""
+        raise NotImplementedError
+
+    def get_total_tokens_used(self) -> int:
+        """Return the cumulative number of tokens used by this client."""
+        raise NotImplementedError
+
     def close(self) -> None:
         """Releases any underlying resources held by the client."""
         raise NotImplementedError

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ PyPDF2
 reportlab
 PyQt6
 pydantic
+graphviz


### PR DESCRIPTION
## Summary
- visualize graph with optional highlighted node and write initial/final images automatically
- record execution time and token usage for each node
- expose token usage tracking in OpenAI and fake LLM clients and protocol
- generate graph image before orchestration starts and add Graphviz dependency

## Testing
- `apt-get update` *(fails: repository 403)*
- `pip install graphviz` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b556293d1883318495b9c248142652