### PR TITLE
Include runtime metrics in graph visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 - Experimental Planning: Generates hypotheses and designs experiments automatically.
 - User-Friendly GUI: Easily configure and launch workflows with real-time monitoring.
 - Customizable Workflows: Adjust agent prompts, models, and workflow topology via config.json.
-- Graph Visualization: Export the agent workflow graph to aid debugging and understanding.
+- Graph Visualization: Export the agent workflow graph to aid debugging and understanding. Visualizations highlight the node currently under execution and, after completion, annotate each node with execution time and token usage.
 - Extensible Architecture: Add new agents for specialized tasks.
 
 ## Table of Contents
@@ -52,6 +52,7 @@
 - **Purpose:** Core backend that loads and executes the multi-agent workflow defined in `config.json`.
 - **Key Elements:**
   - **Graph Orchestrator:** The central component that builds a directed acyclic graph (DAG) of agents from the configuration file. It executes the agents in the correct topological order, managing the flow of data between them. It can also export the graph structure for visualization via Graphviz.
+    Visual outputs highlight the node under execution and summarize per-node runtime and token usage.
   - **Dynamic Agent Loading:** Agents are not hardcoded in the orchestrator. Instead, agent classes are dynamically loaded from the `agents` package based on the `type` specified for each node in the `config.json` graph.
   - **Agent Network:** The default workflow consists of specialized agents, including:
     - `PDFLoaderAgent`: Loads and extracts text from PDF files.

--- a/tests/test_visualize_metrics.py
+++ b/tests/test_visualize_metrics.py
@@ -1,0 +1,22 @@
+import os
+import multi_agent_llm_system
+from llm_fake import FakeLLM
+from agents.base_agent import Agent
+from agents.registry import register_agent
+
+@register_agent("MetricAgent")
+class MetricAgent(Agent):
+    def execute(self, inputs):
+        return {}
+
+def test_visualize_includes_metrics(tmp_path, monkeypatch):
+    config = {"nodes": [{"id": "a", "type": "MetricAgent"}], "edges": []}
+    app_config = {"system_variables": {"default_llm_model": "test"}}
+    orchestrator = multi_agent_llm_system.GraphOrchestrator(config, FakeLLM(), app_config)
+    orchestrator.node_metrics["a"] = {"execution_time_sec": 1.23, "tokens_used": 45}
+    monkeypatch.setattr(multi_agent_llm_system, "Digraph", None)
+    monkeypatch.setattr(multi_agent_llm_system, "ExecutableNotFound", None)
+    output = tmp_path / "graph"
+    orchestrator.visualize(str(output))
+    dot_content = (tmp_path / "graph.gv").read_text()
+    assert "1.23s, 45 tok" in dot_content


### PR DESCRIPTION
## Summary
- Annotate graph nodes with execution time and token usage
- Highlight active node and skip initial graph when graph cannot run
- Document new visualization features and add regression test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5d82b496883318f333904434128b8