### PR TITLE
feat(gui): display agent graph during workflow

### DIFF
--- a/multi_agent_llm_system.py
+++ b/multi_agent_llm_system.py
@@ -22,6 +22,8 @@ from utils import (
     log_status,
     set_status_callback,
     load_app_config,  # pylint: disable=unused-import
+    set_graph_callback,  # re-exported for GUI usage
+    report_graph_visualization,
 )
 
 # Configuration schema validation
@@ -187,6 +189,7 @@ class GraphOrchestrator:
             with open(dot_path, "w", encoding="utf-8") as f:
                 f.write("\n".join(dot_lines))
             log_status(f"[GraphOrchestrator] INFO: graphviz package not available. DOT file saved to {dot_path}")
+            report_graph_visualization(dot_path)
             return dot_path
 
         dot = Digraph(comment="Agent Graph", format=output_format)
@@ -207,10 +210,12 @@ class GraphOrchestrator:
         try:
             output_file = dot.render(output_path, cleanup=True)
             log_status(f"[GraphOrchestrator] INFO: Graph visualization saved to {output_file}")
+            report_graph_visualization(output_file)
             return output_file
         except ExecutableNotFound:
             dot_path = dot.save(output_path + ".gv")
             log_status(f"[GraphOrchestrator] WARNING: Graphviz executable not found. DOT file saved to {dot_path}")
+            report_graph_visualization(dot_path)
             return dot_path
 
     def run(self, initial_inputs: Dict[str, Any], project_base_output_dir: str):

--- a/utils.py
+++ b/utils.py
@@ -47,6 +47,7 @@ openai_errors = {
 
 APP_CONFIG: dict = {}
 _STATUS_CALLBACK = {"func": print}
+_GRAPH_CALLBACK = {"func": None}
 
 UTIL_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -57,6 +58,12 @@ def set_status_callback(callback_func):
     _STATUS_CALLBACK["func"] = callback_func
 
 
+def set_graph_callback(callback_func):
+    """Set the callback used to report generated graph visualizations."""
+
+    _GRAPH_CALLBACK["func"] = callback_func
+
+
 def log_status(message: str):
     """Log ``message`` using the configured status callback."""
 
@@ -65,6 +72,14 @@ def log_status(message: str):
         callback(message)
     else:
         print(message)
+
+
+def report_graph_visualization(path: str):
+    """Invoke the graph visualization callback with ``path`` if set."""
+
+    callback = _GRAPH_CALLBACK.get("func")
+    if callable(callback):
+        callback(path)
 
 
 def load_app_config(config_path: str = "config.json", main_script_dir: Optional[str] = None):


### PR DESCRIPTION
## Summary
- allow backend to emit graph visualization paths via new callbacks
- broadcast visualization updates from orchestrator for each graph render
- extend GUI to show latest agent graph image during execution

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2b7f31648833195c4fcc604d2beaf