### PR TITLE
Expand OpenAI model coverage in JSON tests

### DIFF
--- a/tests/agent_openai_test_cases.json
+++ b/tests/agent_openai_test_cases.json
@@ -9,24 +9,42 @@
     "agent": "DeepResearchSummarizerAgent",
     "prompt": "Explain deep research",
     "system": "Deep research system",
-    "model": "gpt-4o"
+    "model": "gpt-4"
   },
   {
     "agent": "WebResearcherAgent",
     "prompt": "Search the web",
     "system": "Web research system",
-    "model": "gpt-4o"
+    "model": "gpt-4-turbo"
   },
   {
     "agent": "KnowledgeIntegratorAgent",
     "prompt": "Integrate knowledge",
     "system": "Integrate system",
-    "model": "gpt-3.5-turbo"
+    "model": "gpt-4.1"
   },
   {
     "agent": "HypothesisGeneratorAgent",
     "prompt": "Generate hypotheses",
     "system": "Hypothesis system",
-    "model": "gpt-3.5-turbo"
+    "model": "gpt-4.1-mini"
+  },
+  {
+    "agent": "StrategyPlannerAgent",
+    "prompt": "Plan strategy",
+    "system": "Planning system",
+    "model": "gpt-4o"
+  },
+  {
+    "agent": "AssistantAgent",
+    "prompt": "Assist tasks",
+    "system": "Assistance system",
+    "model": "gpt-4o-mini"
+  },
+  {
+    "agent": "FutureAgent",
+    "prompt": "Predict future",
+    "system": "Prediction system",
+    "model": "gpt-5"
   }
 ]

--- a/tests/test_agent_json_api_calls.py
+++ b/tests/test_agent_json_api_calls.py
@@ -50,3 +50,19 @@ def test_call_openai_api_from_json(monkeypatch, case):
     assert captured["model"] == case["model"]
     assert captured["api_key"] == "test-key"
     assert captured["timeout"] == 10
+
+
+def test_json_covers_all_openai_models():
+    """Verify the JSON includes every OpenAI model up to GPT-5."""
+    expected_models = {
+        "gpt-3.5-turbo",
+        "gpt-4",
+        "gpt-4-turbo",
+        "gpt-4.1",
+        "gpt-4.1-mini",
+        "gpt-4o",
+        "gpt-4o-mini",
+        "gpt-5",
+    }
+    models_in_json = {case["model"] for case in AGENT_TEST_CASES}
+    assert models_in_json == expected_models


### PR DESCRIPTION
## Summary
- expand `agent_openai_test_cases.json` with entries for every OpenAI model through GPT-5
- add regression test ensuring JSON covers all expected models

## Testing
- `pytest tests/test_agent_json_api_calls.py`

------
https://chatgpt.com/codex/tasks/task_e_68c343f9810083318ef6acbf3e2d3550