### PR TITLE
Add agent to persist PDF summaries

### DIFF
--- a/agents/summary_writer_agent.py
+++ b/agents/summary_writer_agent.py
@@ -1,0 +1,47 @@
+"""Agent that writes individual PDF summaries to text files."""
+
+import os
+from typing import List, Dict
+
+from .base_agent import Agent
+from .registry import register_agent
+from utils import log_status
+
+
+@register_agent("PDFSummaryWriterAgent")
+class PDFSummaryWriterAgent(Agent):
+    """Persist each PDF summary to a separate text file."""
+
+    def execute(self, inputs: dict) -> dict:  # type: ignore[override]
+        """Write summaries from ``inputs`` to text files.
+
+        Parameters
+        ----------
+        inputs: dict
+            Expected to contain ``summaries_to_write`` which is a list of
+            dictionaries with keys ``summary`` and ``original_pdf_path``.
+        """
+        summaries: List[Dict[str, str]] = inputs.get("summaries_to_write", [])
+        output_dir = self.config_params.get("output_dir", "pdf_summaries")
+        os.makedirs(output_dir, exist_ok=True)
+
+        written_files = []
+        for item in summaries:
+            summary_text = item.get("summary", "")
+            orig_path = item.get("original_pdf_path", "document.pdf")
+            if not summary_text:
+                continue
+            base_name = os.path.splitext(os.path.basename(orig_path))[0]
+            file_path = os.path.join(output_dir, f"{base_name}.txt")
+            try:
+                with open(file_path, "w", encoding="utf-8") as f:
+                    f.write(summary_text)
+                written_files.append(file_path)
+                log_status(
+                    f"[{self.agent_id}] INFO: Wrote summary for '{orig_path}' to '{file_path}'."
+                )
+            except OSError as e:
+                log_status(
+                    f"[{self.agent_id}] ERROR: Failed to write summary for '{orig_path}': {e}"
+                )
+        return {"written_summary_files": written_files}

--- a/pdf_summarize_and_save_config.json
+++ b/pdf_summarize_and_save_config.json
@@ -1,0 +1,94 @@
+{
+  "system_variables": {
+    "openai_api_key": "YOUR_OPENAI_API_KEY",
+    "llm_client": "openai",
+    "default_llm_model": "gpt-4o",
+    "models": {
+      "pdf_summarizer": "gpt-4o",
+      "multi_doc_synthesizer_model": "gpt-4o"
+    },
+    "openai_api_timeout_seconds": 120
+  },
+  "agent_prompts": {
+    "pdf_summarizer_sm": "You are an expert academic summarizer. Produce a concise summary of the following text:\n{text_content}",
+    "multi_doc_synthesizer_sm": "Synthesize these individual summaries into a unified overview:\n{all_summaries_text}"
+  },
+  "graph_definition": {
+    "nodes": [
+      {
+        "id": "initial_input_provider",
+        "type": "InitialInputProvider",
+        "config": {
+          "description": "Provides the initial list of PDF paths."
+        }
+      },
+      {
+        "id": "pdf_loader_node",
+        "type": "PDFLoaderAgent",
+        "config": {
+          "description": "Loads text from a PDF file.",
+          "loop_over": "all_pdf_paths",
+          "loop_item_input_key": "pdf_path"
+        }
+      },
+      {
+        "id": "pdf_summarizer_node",
+        "type": "PDFSummarizerAgent",
+        "config": {
+          "description": "Summarizes each loaded PDF.",
+          "loop_over": "loader_results",
+          "model_key": "pdf_summarizer",
+          "system_message_key": "pdf_summarizer_sm",
+          "parallel_execution": true
+        }
+      },
+      {
+        "id": "pdf_summary_writer",
+        "type": "PDFSummaryWriterAgent",
+        "config": {
+          "description": "Writes each PDF summary to a text file.",
+          "output_dir": "pdf_summaries"
+        }
+      },
+      {
+        "id": "multi_doc_synthesizer",
+        "type": "MultiDocSynthesizerAgent",
+        "config": {
+          "description": "Combines individual PDF summaries into a single text.",
+          "model_key": "multi_doc_synthesizer_model",
+          "system_message_key": "multi_doc_synthesizer_sm"
+        }
+      }
+    ],
+    "edges": [
+      {
+        "from": "initial_input_provider",
+        "to": "pdf_loader_node",
+        "data_mapping": {
+          "all_pdf_paths": "all_pdf_paths"
+        }
+      },
+      {
+        "from": "pdf_loader_node",
+        "to": "pdf_summarizer_node",
+        "data_mapping": {
+          "results": "loader_results"
+        }
+      },
+      {
+        "from": "pdf_summarizer_node",
+        "to": "pdf_summary_writer",
+        "data_mapping": {
+          "results": "summaries_to_write"
+        }
+      },
+      {
+        "from": "pdf_summarizer_node",
+        "to": "multi_doc_synthesizer",
+        "data_mapping": {
+          "results": "all_pdf_summaries"
+        }
+      }
+    ]
+  }
+}

--- a/tests/test_pdf_summary_writer_agent.py
+++ b/tests/test_pdf_summary_writer_agent.py
@@ -1,0 +1,46 @@
+"""Tests for :class:`PDFSummaryWriterAgent`."""
+
+import os
+import shutil
+import tempfile
+import unittest
+
+from agents.summary_writer_agent import PDFSummaryWriterAgent
+from llm_fake import FakeLLM
+
+
+class TestPDFSummaryWriterAgent(unittest.TestCase):
+    """Ensure the summary writer agent persists summaries to disk."""
+
+    def setUp(self):
+        os.environ["OPENAI_API_KEY"] = "dummy"
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir)
+        del os.environ["OPENAI_API_KEY"]
+
+    def test_writes_files(self):
+        summaries = [
+            {"summary": "First", "original_pdf_path": "a.pdf"},
+            {"summary": "Second", "original_pdf_path": "b.pdf"},
+        ]
+        app_config = {"system_variables": {"models": {}}, "agent_prompts": {}}
+        fake = FakeLLM(app_config, response_map={})
+        agent = PDFSummaryWriterAgent(
+            "writer",
+            "PDFSummaryWriterAgent",
+            {"output_dir": self.temp_dir},
+            fake,
+            app_config,
+        )
+        result = agent.execute({"summaries_to_write": summaries})
+        paths = result["written_summary_files"]
+        self.assertEqual(len(paths), 2)
+        for expected, path in zip(["First", "Second"], sorted(paths)):
+            with open(path, "r", encoding="utf-8") as fh:
+                self.assertEqual(fh.read(), expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `PDFSummaryWriterAgent` to store each PDF summary as a text file
- add configuration example `pdf_summarize_and_save_config.json` with writer node
- test summary writing agent

## Testing
- `pytest tests/test_pdf_summary_writer_agent.py -q`
- `pytest tests/test_pdf_summarizer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c345ed32e88331b1f8b726d477a097