### PR TITLE
Enhance GUI with menus and route configuration

### DIFF
--- a/predefined_routes.ini
+++ b/predefined_routes.ini
@@ -1,0 +1,3 @@
+[routes]
+# Define predefined routes here, e.g.:
+# route1 = start->middle->end


### PR DESCRIPTION
## Summary
- add menu bar with options to save logs, export graph JPGs, load predefined routes, and open graph definition window
- load predefined routes from `predefined_routes.ini`
- provide placeholder graph definition dialog

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c35841f6f08331b9fde44ad1098810