### PR TITLE
Fix PyQt6 QAction import

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -32,13 +32,12 @@ def install_dependencies():
 
 try:
     from PyQt6.QtCore import QTimer, QObject, pyqtSignal, Qt
-    from PyQt6.QtGui import QFont, QPixmap
+    from PyQt6.QtGui import QFont, QPixmap, QAction
     from PyQt6.QtWidgets import (
         QApplication,
         QFileDialog,
         QLabel,
         QMenuBar,
-        QAction,
         QMessageBox,
         QDialog,
         QPushButton,


### PR DESCRIPTION
## Summary
- fix PyQt6 QAction import location in GUI startup

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c3644237ec833195123d6a60a913d9