### PR TITLE
Allow GUI dependency install before PyQt import

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@
 ```bash
 python gui.py
 ```
+- If PyQt is not installed, run `python gui.py --install-deps` to install required dependencies before launching.
 - Use the GUI to select your PDF folder, output directory, and optional experimental data/config.
 - Click "Start Integrated Analysis" to launch the workflow.
 - Monitor progress and status in the GUI.

--- a/gui.py
+++ b/gui.py
@@ -30,6 +30,14 @@ def install_dependencies():
     except FileNotFoundError:
         print("[Dependency Check] 'pip' command not found. Please ensure pip is installed and in your PATH.")
 
+# Allow installing dependencies before attempting to import PyQt.
+# This enables running ``python gui.py --install-deps`` even when PyQt
+# itself is not yet installed.
+if "--install-deps" in sys.argv:
+    install_dependencies()
+    # Remove the flag so it does not interfere with later argument parsing.
+    sys.argv.remove("--install-deps")
+
 try:
     from PyQt6.QtCore import QTimer, QObject, pyqtSignal, Qt
     from PyQt6.QtGui import QAction, QFont, QPixmap
@@ -892,19 +900,6 @@ class GraphDefinitionWindow(QDialog):
 
 
 if __name__ == '__main__':
-    import argparse
-
-    parser = argparse.ArgumentParser(description="Run the Multi-Agent Research Assistant GUI.")
-    parser.add_argument(
-        "--install-deps",
-        action="store_true",
-        help="Install dependencies from requirements.txt before launching the GUI.",
-    )
-    cli_args = parser.parse_args()
-
-    if cli_args.install_deps:
-        install_dependencies()
-
     app = QApplication(sys.argv)
     app.setQuitOnLastWindowClosed(True)
 


### PR DESCRIPTION
## Summary
- Allow `python gui.py --install-deps` to install requirements before importing PyQt
- Document the `--install-deps` option in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c3ddd627708331b271bae032257159