### PR TITLE
feat(gui): install required packages with flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@
 ```bash
 python gui.py
 ```
-- If PyQt is not installed, run `python gui.py --install-deps` to install required dependencies before launching.
+- To install required packages automatically, set `auto_install_deps = true` in `predefined_routes.ini` and run `python gui.py --install-deps` before launching.
 - Use the GUI to select your PDF folder, output directory, and optional experimental data/config.
 - Click "Start Integrated Analysis" to launch the workflow.
 - Monitor progress and status in the GUI.

--- a/dependency_installer.py
+++ b/dependency_installer.py
@@ -1,0 +1,62 @@
+"""Utility for installing project dependencies before GUI imports."""
+
+from __future__ import annotations
+
+import configparser
+import os
+import subprocess
+import sys
+
+
+def _install_from_requirements(requirements_path: str) -> None:
+    """Install dependencies listed in ``requirements_path`` using pip.
+
+    Parameters
+    ----------
+    requirements_path: str
+        Path to the requirements file.
+    """
+    if not os.path.exists(requirements_path):
+        print("[Dependency Check] requirements.txt not found. Skipping installation.")
+        return
+
+    print("[Dependency Check] Checking and installing dependencies from requirements.txt...")
+    try:
+        subprocess.check_call([sys.executable, "-m", "pip", "install", "-r", requirements_path])
+        print("[Dependency Check] All dependencies are satisfied.")
+    except subprocess.CalledProcessError:
+        print(
+            "[Dependency Check] Failed to install dependencies. Please install them manually using 'pip install -r requirements.txt'"
+        )
+    except FileNotFoundError:
+        print("[Dependency Check] 'pip' command not found. Please ensure pip is installed and in your PATH.")
+
+
+def _auto_install_enabled(routes_path: str) -> bool:
+    """Return ``True`` if auto-installation is enabled in routes INI file."""
+    config = configparser.ConfigParser()
+    try:
+        config.read(routes_path)
+        return config.getboolean("options", "auto_install_deps")
+    except (configparser.Error, ValueError):
+        return False
+
+
+def maybe_install_deps(routes_path: str | None = None) -> None:
+    """Install dependencies if enabled in ``routes_path``.
+
+    Parameters
+    ----------
+    routes_path: str | None
+        Path to the routes INI file. If ``None``, ``predefined_routes.ini`` in the
+        current directory is used.
+    """
+    base_dir = os.path.dirname(os.path.abspath(__file__))
+    if routes_path is None:
+        routes_path = os.path.join(base_dir, "predefined_routes.ini")
+
+    if _auto_install_enabled(routes_path):
+        requirements = os.path.join(base_dir, "requirements.txt")
+        _install_from_requirements(requirements)
+    else:
+        print("[Dependency Check] Auto installation disabled via routes configuration.")

--- a/gui.py
+++ b/gui.py
@@ -2,7 +2,6 @@
 
 import datetime
 import os
-import subprocess
 import sys
 import threading
 import time  # Added for small delay in closeEvent
@@ -10,31 +9,13 @@ import traceback
 import configparser
 
 # pylint: disable=missing-function-docstring, import-error, broad-exception-caught
-
-
-def install_dependencies():
-    """Install dependencies from ``requirements.txt`` if present."""
-    requirements_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "requirements.txt")
-    if not os.path.exists(requirements_path):
-        print("[Dependency Check] requirements.txt not found. Skipping installation.")
-        return
-
-    print("[Dependency Check] Checking and installing dependencies from requirements.txt...")
-    try:
-        subprocess.check_call([sys.executable, "-m", "pip", "install", "-r", requirements_path])
-        print("[Dependency Check] All dependencies are satisfied.")
-    except subprocess.CalledProcessError:
-        print(
-            "[Dependency Check] Failed to install dependencies. Please install them manually using 'pip install -r requirements.txt'"
-        )
-    except FileNotFoundError:
-        print("[Dependency Check] 'pip' command not found. Please ensure pip is installed and in your PATH.")
-
 # Allow installing dependencies before attempting to import PyQt.
 # This enables running ``python gui.py --install-deps`` even when PyQt
 # itself is not yet installed.
 if "--install-deps" in sys.argv:
-    install_dependencies()
+    from dependency_installer import maybe_install_deps
+
+    maybe_install_deps()
     # Remove the flag so it does not interfere with later argument parsing.
     sys.argv.remove("--install-deps")
 

--- a/predefined_routes.ini
+++ b/predefined_routes.ini
@@ -1,3 +1,7 @@
 [routes]
 # Define predefined routes here, e.g.:
 # route1 = start->middle->end
+
+[options]
+# Set to true to allow ``gui.py --install-deps`` to install packages automatically
+auto_install_deps = true


### PR DESCRIPTION
## Summary
- move dependency installation into new `dependency_installer` module
- allow GUI to auto-install packages when `--install-deps` flag and `auto_install_deps` option are set
- document new GUI usage and routes flag

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3e002e4c483318793f7fefddb5828