### PR TITLE
Migrate OpenAI client to Responses API

### DIFF
--- a/llm_openai.py
+++ b/llm_openai.py
@@ -72,7 +72,7 @@ class OpenAILLM(LLMClient):
                  model: Optional[str] = None,
                  temperature: Optional[float] = None,
                  extra: Optional[Dict] = None) -> str:  # pylint: disable=too-many-arguments, too-many-locals
-        """Send a chat completion request to the OpenAI API."""
+        """Send a Responses API request to the OpenAI API."""
         chosen_model = model if model else get_model_name(self.app_config)
         sys_msg = system if system else "You are a helpful assistant."
         temp = temperature
@@ -106,7 +106,7 @@ class OpenAILLM(LLMClient):
         try:
             params = {
                 "model": chosen_model,
-                "messages": [
+                "input": [
                     {"role": "system", "content": sys_msg},
                     {"role": "user", "content": prompt},
                 ],
@@ -118,14 +118,14 @@ class OpenAILLM(LLMClient):
             if conversation_id:
                 params["conversation_id"] = conversation_id
 
-            response = self.client.chat.completions.create(**params)
+            response = self.client.responses.create(**params)
             usage = getattr(getattr(response, "usage", None), "total_tokens", 0)
             self.last_token_usage = usage
             self.total_tokens_used += usage
 
             try:
-                result = response.choices[0].message["content"].strip()  # type: ignore[index]
-            except (TypeError, AttributeError, IndexError, KeyError):
+                result = response.output_text.strip()
+            except (TypeError, AttributeError):
                 log_status(
                     f"[LLM] LLM_CALL_ERROR: Model='{chosen_model}' response has no textual output."
                 )

--- a/memory.md
+++ b/memory.md
@@ -140,9 +140,9 @@ if results.data:
     if first_result.content:
         formatted_results = first_result.content[0].text
 
-completion = client.chat.completions.create(
+response = client.responses.create(
     model="gpt-4o",
-    messages=[
+    input=[
         {
             "role": "system",
             "content": "You are a helpful assistant. Produce a concise answer to the query based on the provided sources."
@@ -154,7 +154,7 @@ completion = client.chat.completions.create(
     ],
 )
 
-print(completion.choices[0].message.content)
+print(response.output_text)
 ```
 
 This pattern of retrieve-then-synthesize is a cornerstone of building knowledgeable and reliable agents.

--- a/tests/test_llm_clients.py
+++ b/tests/test_llm_clients.py
@@ -20,15 +20,12 @@ def test_fake_llm_uses_cache_without_incrementing_tokens():
 def test_openai_llm_wraps_timeout_error(monkeypatch):
     """OpenAILLM.complete should wrap APITimeoutError in LLMError."""
     class TimeoutOpenAI:
-        class Chat:  # pylint: disable=too-few-public-methods
-            class Completions:  # pylint: disable=too-few-public-methods
-                def create(self, **kwargs):  # noqa: D401
-                    raise APITimeoutError("timeout")
-
-            completions = Completions()
+        class Responses:  # pylint: disable=too-few-public-methods
+            def create(self, **kwargs):  # noqa: D401
+                raise APITimeoutError("timeout")
 
         def __init__(self, *args, **kwargs):
-            self.chat = self.Chat()
+            self.responses = self.Responses()
 
     monkeypatch.setattr(llm_openai, "OpenAI", TimeoutOpenAI)
     llm = OpenAILLM({}, api_key="test-key")


### PR DESCRIPTION
## Summary
- refactor OpenAI client to use the Responses API for text generation
- align documentation and tests with Responses API usage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3e4d0cba48331bdcfe5df298b82be