### PR TITLE
Handle OpenAI Responses output_text

### DIFF
--- a/tests/test_llm_clients.py
+++ b/tests/test_llm_clients.py
@@ -17,7 +17,7 @@ def test_fake_llm_uses_cache_without_incrementing_tokens():
     assert llm.get_total_tokens_used() == tokens_after_first
 
 
-def test_openai_llm_wraps_timeout_error(monkeypatch):
+def test_openai_llm_wraps_timeout_error(monkeypatch, tmp_path):
     """OpenAILLM.complete should wrap APITimeoutError in LLMError."""
     class TimeoutOpenAI:
         class Responses:  # pylint: disable=too-few-public-methods
@@ -28,7 +28,33 @@ def test_openai_llm_wraps_timeout_error(monkeypatch):
             self.responses = self.Responses()
 
     monkeypatch.setattr(llm_openai, "OpenAI", TimeoutOpenAI)
-    llm = OpenAILLM({}, api_key="test-key")
+    app_config = {"system_variables": {"cache_dir": str(tmp_path)}}
+    llm = OpenAILLM(app_config, api_key="test-key")
 
     with pytest.raises(LLMError):
         llm.complete(system="sys", prompt="hi", model="gpt-3")
+
+
+def test_openai_llm_uses_output_text_when_content_missing(monkeypatch, tmp_path):
+    """Response.output_text should be used if output content is absent."""
+
+    class DummyOpenAI:
+        class Responses:  # pylint: disable=too-few-public-methods
+            class DummyResponse:  # pylint: disable=too-few-public-methods
+                def __init__(self):
+                    self.output = [type("Obj", (), {"content": []})()]
+                    self.output_text = "Hello world"
+                    self.usage = type("Usage", (), {"total_tokens": 5})()
+
+            def create(self, **kwargs):  # noqa: D401
+                return self.DummyResponse()
+
+        def __init__(self, *args, **kwargs):
+            self.responses = self.Responses()
+
+    monkeypatch.setattr(llm_openai, "OpenAI", DummyOpenAI)
+    app_config = {"system_variables": {"cache_dir": str(tmp_path)}}
+    llm = OpenAILLM(app_config, api_key="test-key")
+
+    result = llm.complete(system="sys", prompt="hi", model="gpt-3")
+    assert result == "Hello world"


### PR DESCRIPTION
## Summary
- Handle OpenAI Responses output_text when regular content is missing
- Add regression tests covering output_text parsing and caching isolation

## Testing
- `pytest tests/test_llm_clients.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c40004ad54833180c4c993e8b7d720