### PR TITLE
Fix DeepResearchSummarizer missing summary key

### DIFF
--- a/agents/deep_research_summarizer_agent.py
+++ b/agents/deep_research_summarizer_agent.py
@@ -34,13 +34,19 @@ class DeepResearchSummarizerAgent(Agent):
             inputs (dict): A dictionary containing 'user_query' and 'vector_store_path'.
 
         Returns:
-            dict: A dictionary containing the 'deep_research_summary'.
+            dict: A dictionary with a ``deep_research_summary`` field
+            (empty string on failure) and optionally an ``error`` message
+            describing any issues encountered during summarization.
         """
         log_status(f"[{self.agent_id}] INFO: Deep research summarizer agent is processing inputs: {inputs}")
 
         user_query = inputs.get("user_query")
         if not user_query:
-            return {"error": "Input 'user_query' was not provided."}
+            log_status(f"[{self.agent_id}] ERROR: Input 'user_query' was not provided.")
+            return {
+                "deep_research_summary": "",
+                "error": "Input 'user_query' was not provided.",
+            }
 
         vector_store_path = inputs.get("vector_store_path")
         if not vector_store_path:
@@ -48,15 +54,20 @@ class DeepResearchSummarizerAgent(Agent):
             return {"deep_research_summary": "No new documents were provided to generate a deep summary."}
 
         if not os.path.exists(vector_store_path):
-            log_status(f"[{self.agent_id}] ERROR: Vector store not found at path: {vector_store_path}")
-            return {"error": f"Vector store not found at path: {vector_store_path}"}
+            log_status(
+                f"[{self.agent_id}] ERROR: Vector store not found at path: {vector_store_path}"
+            )
+            return {
+                "deep_research_summary": "",
+                "error": f"Vector store not found at path: {vector_store_path}",
+            }
 
         if FAISS is None:
             error_msg = (
                 "langchain_community.vectorstores is not available. Install the package to enable FAISS support."
             )
             log_status(f"[{self.agent_id}] ERROR: {error_msg}")
-            return {"error": error_msg}
+            return {"deep_research_summary": "", "error": error_msg}
 
         try:
             log_status(f"[{self.agent_id}] INFO: Loading FAISS vector store from '{vector_store_path}'.")
@@ -104,4 +115,4 @@ class DeepResearchSummarizerAgent(Agent):
         except (OSError, ValueError, RuntimeError) as exc:
             error_msg = f"Failed during deep research summarization: {exc}"
             log_status(f"[{self.agent_id}] ERROR: {error_msg}")
-            return {"error": error_msg}
+            return {"deep_research_summary": "", "error": error_msg}

--- a/tests/test_deep_research_summarizer_agent.py
+++ b/tests/test_deep_research_summarizer_agent.py
@@ -1,0 +1,49 @@
+"""Tests for :class:`DeepResearchSummarizerAgent`."""
+
+import os
+import unittest
+
+from agents.deep_research_summarizer_agent import DeepResearchSummarizerAgent
+from llm_fake import FakeLLM
+
+
+class TestDeepResearchSummarizerAgent(unittest.TestCase):
+    """Unit tests for the deep research summarizer agent."""
+
+    def setUp(self):
+        """Ensure an API key is present for components that require it."""
+        os.environ["OPENAI_API_KEY"] = "dummy_key"
+
+    def tearDown(self):
+        """Clean up the dummy API key set in ``setUp``."""
+        del os.environ["OPENAI_API_KEY"]
+
+    def _make_agent(self):
+        app_config = {
+            "system_variables": {"models": {}},
+            "agent_prompts": {"deep_research_summarizer_sm": "You are a helpful summarizer."},
+        }
+        fake_llm = FakeLLM(app_config)
+        config = {
+            "model_key": "deep_research_summarizer_model",
+            "system_message_key": "deep_research_summarizer_sm",
+        }
+        return DeepResearchSummarizerAgent(
+            "test_agent",
+            "DeepResearchSummarizerAgent",
+            config,
+            fake_llm,
+            app_config,
+        )
+
+    def test_missing_user_query_returns_error_and_summary_key(self):
+        """Agent returns an error and empty summary if ``user_query`` is absent."""
+        agent = self._make_agent()
+        result = agent.execute({})
+        self.assertIn("deep_research_summary", result)
+        self.assertIn("error", result)
+        self.assertEqual(result["deep_research_summary"], "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- log and report when `DeepResearchSummarizerAgent` receives no `user_query`
- add unit test verifying the agent always returns a `deep_research_summary` key even on error

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4524492688331a86689db4da8f497