### PR TITLE
Improve deep research pipeline error handling

### DIFF
--- a/agents/deep_research_summarizer_agent.py
+++ b/agents/deep_research_summarizer_agent.py
@@ -50,8 +50,9 @@ class DeepResearchSummarizerAgent(Agent):
 
         vector_store_path = inputs.get("vector_store_path")
         if not vector_store_path:
-            log_status(f"[{self.agent_id}] INFO: No vector store path provided. Skipping summarization.")
-            return {"deep_research_summary": "No new documents were provided to generate a deep summary."}
+            error_msg = "No vector store path provided for deep research summarization."
+            log_status(f"[{self.agent_id}] ERROR: {error_msg}")
+            return {"deep_research_summary": "", "error": error_msg}
 
         if not os.path.exists(vector_store_path):
             log_status(

--- a/agents/memory_agent.py
+++ b/agents/memory_agent.py
@@ -44,16 +44,28 @@ class ShortTermMemoryAgent(Agent):
 
         individual_summaries_list = inputs.get("individual_summaries")
         if not isinstance(individual_summaries_list, list) or not individual_summaries_list:
-            log_status(f"[{self.agent_id}] INFO: Input 'individual_summaries' is missing or empty. No STM will be created.")
-            return {"vector_store_path": None, "individual_summaries": []}
+            log_status(
+                f"[{self.agent_id}] INFO: Input 'individual_summaries' is missing or empty. No STM will be created."
+            )
+            return {
+                "vector_store_path": None,
+                "individual_summaries": [],
+                "error": "No individual summaries were provided to build short-term memory.",
+            }
 
         # Extract summary text from the list of dictionaries
         valid_summaries = [s.get("summary") for s in individual_summaries_list if isinstance(s, dict) and s.get("summary")]
         log_status(f"[{self.agent_id}] INFO: Found {len(valid_summaries)} valid summaries.")
 
         if not valid_summaries:
-            log_status(f"[{self.agent_id}] INFO: No valid summary strings found in 'individual_summaries'. No STM will be created.")
-            return {"vector_store_path": None, "individual_summaries": []}
+            log_status(
+                f"[{self.agent_id}] INFO: No valid summary strings found in 'individual_summaries'. No STM will be created."
+            )
+            return {
+                "vector_store_path": None,
+                "individual_summaries": [],
+                "error": "No valid summary strings were found to build short-term memory.",
+            }
 
         if FAISS is None:
             error_msg = "langchain_community.vectorstores is required but not installed."

--- a/tests/test_deep_research_summarizer_agent.py
+++ b/tests/test_deep_research_summarizer_agent.py
@@ -44,6 +44,13 @@ class TestDeepResearchSummarizerAgent(unittest.TestCase):
         self.assertIn("error", result)
         self.assertEqual(result["deep_research_summary"], "")
 
+    def test_missing_vector_store_path_returns_error(self):
+        """Agent errors when no vector store path is supplied."""
+        agent = self._make_agent()
+        result = agent.execute({"user_query": "What is AI?"})
+        self.assertIn("error", result)
+        self.assertEqual(result["deep_research_summary"], "")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_memory_agents.py
+++ b/tests/test_memory_agents.py
@@ -81,6 +81,7 @@ class TestMemoryAgents(unittest.TestCase):
         result = agent.execute({"individual_summaries": "bad"})
         self.assertIsNone(result["vector_store_path"])
         self.assertEqual(result["individual_summaries"], [])
+        self.assertIn("error", result)
 
     def test_long_term_memory_updates_store(self):
         """Long term agent saves summaries to persistent storage."""


### PR DESCRIPTION
## Summary
- surface errors when DeepResearchSummarizer runs without a vector store path
- return explicit errors from ShortTermMemoryAgent when no usable summaries exist
- expand tests for deep research summarizer and memory agent invalid input handling

## Testing
- `pytest tests/test_memory_agents.py::TestMemoryAgents::test_short_term_memory_handles_invalid_input -q`
- `pytest tests/test_deep_research_summarizer_agent.py -q`
- `pytest -q`
- `flake8 agents/deep_research_summarizer_agent.py agents/memory_agent.py tests/test_memory_agents.py tests/test_deep_research_summarizer_agent.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c70f0bd0c883319ca7fa5fa9831936