### PR TITLE
Handle batched hypotheses in experiment designer

### DIFF
--- a/agents/experiment_designer_agent.py
+++ b/agents/experiment_designer_agent.py
@@ -10,19 +10,71 @@ class ExperimentDesignerAgent(Agent):
     """Generate an experimental protocol for a single hypothesis."""
 
     def execute(self, inputs: dict) -> dict:  # Type hint for dict
-        """Produce an experiment design for a single hypothesis in ``inputs``."""
+        """Produce experiment designs for one or many hypotheses."""
+
         current_system_message = self.get_formatted_system_message()
+
+        hypotheses_list = inputs.get("hypotheses_list")
+        # When the agent receives a batch of hypotheses (e.g., during tests or
+        # when invoked outside of the orchestrator loop) we return a
+        # consolidated response instead of a single design dictionary. Treat
+        # the presence of the list key or an associated error flag as an
+        # indication that batched handling is expected, even if the actual
+        # list value is missing.
+        if (
+            isinstance(hypotheses_list, list)
+            or "hypotheses_list" in inputs
+            or inputs.get("hypotheses_list_error")
+        ):
+            if current_system_message.startswith("ERROR:"):
+                return {"experiment_designs_list": [], "error": current_system_message}
+            return self._design_for_hypothesis_list(hypotheses_list, inputs, current_system_message)
+
         if current_system_message.startswith("ERROR:"):
             return {"experiment_design": "", "error": current_system_message}
 
-        hypo_obj = inputs.get("hypothesis", {})  # Expects a single hypothesis object
         had_upstream_error = inputs.get("hypothesis_error", False)
-
         if had_upstream_error:
             log_status(f"[{self.agent_id}] INPUT_ERROR: Upstream error indicated for hypothesis. Cannot design experiment.")
             return {"experiment_design": "", "error": "Upstream error in hypothesis provided."}
 
-        # Validate the structure of the hypothesis object
+        hypo_obj = inputs.get("hypothesis", {})
+        return self._design_single_hypothesis(hypo_obj, current_system_message)
+
+    def _design_for_hypothesis_list(self, hypotheses_list, inputs, current_system_message):
+        """Generate experiment designs for a list of hypotheses."""
+
+        if inputs.get("hypotheses_list_error") or inputs.get("error"):
+            error_msg = inputs.get(
+                "error",
+                "Upstream error flagged for hypotheses list. Cannot design experiments.",
+            )
+            log_status(f"[{self.agent_id}] INPUT_ERROR: {error_msg}")
+            return {"experiment_designs_list": [], "error": error_msg}
+
+        if not hypotheses_list:
+            log_status(f"[{self.agent_id}] INFO: No hypotheses provided for experiment design.")
+            return {
+                "experiment_designs_list": [],
+                "error": "No hypotheses were supplied for experiment design.",
+            }
+
+        designs = []
+        errors = []
+        for idx, hypothesis_entry in enumerate(hypotheses_list):
+            design = self._design_single_hypothesis(hypothesis_entry, current_system_message)
+            designs.append(design)
+            if design.get("error"):
+                errors.append({"index": idx, "error": design["error"]})
+
+        output = {"experiment_designs_list": designs}
+        if errors:
+            output["errors"] = errors
+        return output
+
+    def _design_single_hypothesis(self, hypo_obj, current_system_message):
+        """Generate an experiment design for a single hypothesis object."""
+
         if not isinstance(hypo_obj, dict) or \
            not isinstance(hypo_obj.get('hypothesis'), str) or not hypo_obj['hypothesis'].strip() or \
            not isinstance(hypo_obj.get('justification'), str):


### PR DESCRIPTION
## Summary
- update `ExperimentDesignerAgent` so it can generate experiment designs for entire hypothesis lists as well as single entries
- add shared helpers to validate hypotheses, propagate upstream errors, and aggregate per-item results when batching

## Testing
- pytest tests/test_experiment_designer_agent.py -q
- pytest tests/test_agent_integration.py -q

------
https://chatgpt.com/codex/tasks/task_e_68c9a0765a008331b2a6097711dff8ba