### PR TITLE
Improve knowledge integration data flow

### DIFF
--- a/agents/knowledge_integrator_agent.py
+++ b/agents/knowledge_integrator_agent.py
@@ -1,5 +1,7 @@
 """Agent that integrates multiple knowledge sources into a coherent brief."""
 
+import json
+
 from llm import LLMError
 
 from .base_agent import Agent
@@ -16,51 +18,126 @@ class KnowledgeIntegratorAgent(Agent):
         if current_system_message.startswith("ERROR:"):
             return {"integrated_knowledge_brief": "", "error": current_system_message}
 
-        multi_doc_synthesis = inputs.get(
-            "multi_doc_synthesis", "N/A (No multi-document synthesis provided or error upstream.)"
-        )
-        web_research_summary = inputs.get(
-            "web_research_summary", "N/A (No web research summary provided or error upstream.)"
-        )
-        experimental_data_summary = inputs.get(
-            "experimental_data_summary", "N/A (No experimental data provided or error upstream.)"
-        )
+        def _stringify(value):
+            if isinstance(value, str):
+                return value
+            if value is None:
+                return ""
+            try:
+                return json.dumps(value, ensure_ascii=False, indent=2)
+            except TypeError:
+                return str(value)
 
-        # Check for upstream errors and prepend to content if necessary
-        if inputs.get("multi_doc_synthesis_error"):
-            multi_doc_synthesis = (
-                f"[Error in upstream multi-document synthesis: {inputs.get('error', 'Content unavailable')}]"
-            )
-
-        if inputs.get("web_research_summary_error"):
-            web_research_summary = (
-                f"[Error in upstream web research: {inputs.get('error', 'Content unavailable')}]"
-            )
-
-        if inputs.get("experimental_data_summary_error"):
-            experimental_data_summary = (
-                f"[Error in upstream experimental data loading: {inputs.get('error', 'Content unavailable')}]"
-            )
-
-
-        # Truncate inputs if they are too long
         max_input_segment_len = self.config_params.get("max_input_segment_len", 10000)
-        if len(multi_doc_synthesis) > max_input_segment_len:
-            multi_doc_synthesis = multi_doc_synthesis[:max_input_segment_len] + "\n[...truncated due to length...]"
-        if len(web_research_summary) > max_input_segment_len:
-            web_research_summary = web_research_summary[:max_input_segment_len] + "\n[...truncated due to length...]"
-        # Experimental data is often shorter, but could be truncated if necessary:
-        # if len(experimental_data_summary) > max_input_segment_len:
-        #     experimental_data_summary = experimental_data_summary[:max_input_segment_len] + "\n[...truncated due to length...]"
+        sources_config = [
+            (
+                "multi_doc_synthesis",
+                "Cross-document synthesis derived from the PDF corpus",
+                "N/A (No multi-document synthesis provided or error upstream.)",
+            ),
+            (
+                "deep_research_summary",
+                "Deep-research summary grounded in the user query",
+                "N/A (No deep-research synthesis provided or error upstream.)",
+            ),
+            (
+                "web_research_summary",
+                "Web research summary providing broader context",
+                "N/A (No web research summary provided or error upstream.)",
+            ),
+            (
+                "experimental_data_summary",
+                "Experimental data summary",
+                "N/A (No experimental data provided or error upstream.)",
+            ),
+        ]
+
+        sections: list[tuple[str, str]] = []
+        contributing_agents: set[str] = set()
+
+        for key, label, default_text in sources_config:
+            raw_content = inputs.get(key)
+            section_text = _stringify(raw_content)
+            if not section_text or not section_text.strip():
+                section_text = default_text
+            if inputs.get(f"{key}_error"):
+                err_msg = (
+                    inputs.get(f"{key}_error_message")
+                    or inputs.get("error")
+                    or "Content unavailable"
+                )
+                source_name = inputs.get(f"{key}_source", "unknown upstream agent")
+                section_text = (
+                    f"[Error reported by {source_name} for '{key}': {err_msg}]"
+                )
+            source_agent = inputs.get(f"{key}_source")
+            if source_agent:
+                contributing_agents.add(source_agent)
+                label_text = f"{label} (source: {source_agent})"
+            else:
+                label_text = label
+            if len(section_text) > max_input_segment_len:
+                section_text = section_text[:max_input_segment_len] + "\n[...truncated due to length...]"
+            sections.append((label_text, section_text))
+
+        known_keys = {cfg[0] for cfg in sources_config}
+        for key in sorted(inputs.keys()):
+            if key in known_keys or key.endswith(("_error", "_error_message", "_source")):
+                continue
+            source_agent = inputs.get(f"{key}_source")
+            if not source_agent:
+                continue
+            supplemental_text = _stringify(inputs.get(key))
+            if not supplemental_text or not supplemental_text.strip():
+                continue
+            if inputs.get(f"{key}_error"):
+                err_msg = (
+                    inputs.get(f"{key}_error_message")
+                    or inputs.get("error")
+                    or "Content unavailable"
+                )
+                supplemental_text = (
+                    f"[Error reported by {source_agent} for '{key}': {err_msg}]"
+                )
+            if len(supplemental_text) > max_input_segment_len:
+                supplemental_text = (
+                    supplemental_text[:max_input_segment_len]
+                    + "\n[...truncated due to length...]"
+                )
+            contributing_agents.add(source_agent)
+            sections.append(
+                (
+                    f"Additional context from {source_agent} ({key})",
+                    supplemental_text,
+                )
+            )
+
+        if not sections:
+            sections.append(
+                (
+                    "No upstream context provided",
+                    "N/A - Upstream agents did not supply any usable context.",
+                )
+            )
+
+        contributor_line = ""
+        if contributing_agents:
+            contributor_line = (
+                "Participating agents: "
+                + ", ".join(sorted(contributing_agents))
+                + ".\n\n"
+            )
+
+        prompt_sections = []
+        for idx, (label_text, section_text) in enumerate(sections, start=1):
+            prompt_sections.append(
+                f"{idx}. {label_text}:\n---\n{section_text}\n---\n"
+            )
 
         prompt = (
-            f"Integrate the following information sources into a comprehensive knowledge brief as per your role:\n\n"
-            f"1. Cross-Document Synthesis from multiple papers:\n---\n{multi_doc_synthesis}\n---\n\n"
-            f"2. Web Research Summary:\n---\n{web_research_summary}\n---\n\n"
-            f"3. Experimental Data Summary:\n---\n{experimental_data_summary}\n---\n\n"
-            # The prompt from config.json already contains detailed instructions on what to include.
-            # This part of the user prompt can be more concise now.
-            f"Provide the integrated knowledge brief based on these sources, adhering to the specific analytical points outlined in your primary instructions (synergies, conflicts, gaps, contradictions, unanswered questions, novel links, limitations)."
+            "Integrate the following information sources into a comprehensive knowledge brief as per your role:\n\n"
+            f"{contributor_line}{''.join(prompt_sections)}"
+            "Provide the integrated knowledge brief based on these sources, adhering to the specific analytical points outlined in your primary instructions (synergies, conflicts, gaps, contradictions, unanswered questions, novel links, limitations)."
         )
 
         temperature = float(self.config_params.get("temperature", 0.6))

--- a/config.json
+++ b/config.json
@@ -11,7 +11,9 @@
     "models": {
       "long_term_memory_model": "gpt-5-mini",
       "pdf_summarizer": "gpt-5-mini",
+      "multi_doc_synthesizer_model": "gpt-5",
       "deep_research_summarizer_model": "gpt-5",
+      "web_research_model": "gpt-5-mini",
       "knowledge_integrator_model": "gpt-5",
       "hypothesis_generator": "gpt-5",
       "experiment_designer": "gpt-5"
@@ -20,7 +22,9 @@
   },
   "agent_prompts": {
     "pdf_summarizer_sm": "You are an expert academic summarizer. Produce a concise, accurate summary (250-500 words) capturing core arguments, methods, key findings, and main conclusions of the provided text.",
+    "multi_doc_synthesizer_sm": "You are a cross-document synthesis expert. Combine the provided individual document summaries into a single, coherent narrative. Highlight converging evidence, disagreements, methodological nuances, open problems, and promising directions that emerge from comparing the documents.",
     "deep_research_summarizer_sm": "You are a deep research synthesis expert. Based on a user's query and a set of retrieved document excerpts, provide a comprehensive and coherent summary that directly addresses the user's question. Synthesize the information from the excerpts to build a complete picture, highlighting key points, and identifying any contradictions or gaps.",
+    "web_researcher_sm": "You are a research assistant performing targeted web-style exploration. Starting from the provided cross-document understanding, surface concise supporting context, conflicting viewpoints, emerging trends, and noteworthy data points from the broader literature or web-accessible knowledge.",
     "experimental_data_loader_sm": "You are a data utility. You will receive text describing experimental results. Present this text as a structured summary. If the text is already a summary, present it as is. Your main role is to make this data available for the next agent.",
     "knowledge_integrator_sm": "You are a senior research strategist. You have been provided with: \n1. A 'cross-document understanding' synthesized from multiple academic papers.\n2. A 'web research summary' providing broader context.\n3. An 'experimental data summary' (which may be 'N/A' if not provided).\nYour task is to integrate these three sources of information into a final, concise 'integrated knowledge brief' (approx. 400-600 words). This brief should highlight the most salient points, synergies, and overall insights. \nIn addition, explicitly identify and articulate the following within the brief:\n- Key contradictions or inconsistencies found across the information sources.\n- Salient unanswered questions that emerge from the synthesis.\n- Underexplored connections or novel links between disparate pieces of information that could suggest new research directions.\n- A summary of the key limitations or gaps in the current overall understanding based on the provided materials.\nThis comprehensive brief, enriched with these specific analytical points, will be the foundation for generating novel hypotheses. Ensure the output remains a single, coherent text document.",
     "hypothesis_generator_sm": "You are a highly insightful research strategist and innovator. Based on the provided 'integrated knowledge brief' (which consolidates information from multiple papers, web research, and experimental data), your task is to:\n1.  **Identify Key Opportunities:** Briefly highlight the most promising areas for novel research based on the integrated knowledge.\n2.  **Generate Hypotheses:** Propose {num_hypotheses} distinct, novel, and groundbreaking hypotheses. Strive for diversity in your hypotheses, exploring different perspectives and unconventional angles. Each hypothesis must be specific, measurable, and testable. For each hypothesis, include a brief justification (1-2 sentences) explaining its novelty and testability.\n\n**Output Format STRICTLY REQUIRED:** Provide your response as a single JSON object with two keys:\n- `\"key_opportunities\"`: A string containing your brief summary of key research opportunities.\n- `\"hypotheses\"`: A JSON array of objects, where each object has two keys: `\"hypothesis\"` (a string with the hypothesis itself) and `\"justification\"` (a string explaining its novelty and testability).\n\nExample JSON output structure:\n```json\n{{\n  \"key_opportunities\": \"The integration of X from papers, Y from web, and Z from experiments points to a critical need to investigate C, particularly exploring unconventional approaches D and E.\",\n  \"hypotheses\": [\n    {{\n      \"hypothesis\": \"Hypothesis 1: Implementing X approach in Y context will lead to Z outcome.\",\n      \"justification\": \"This hypothesis is novel because it combines previously disparate concepts X and Y. It is testable by conducting a controlled experiment measuring Z under specific conditions.\"\n    }},\n    {{\n      \"hypothesis\": \"Hypothesis 2: The underlying mechanism M is responsible for observed phenomenon P, challenging existing theory T.\",\n      \"justification\": \"This hypothesis is novel as it proposes an alternative mechanism M not considered in current theory T. It can be tested by designing an experiment to isolate and verify the activity of M and its correlation with P.\"\n    }}\n  ]\n}}\n```\nEnsure the entire output is a valid JSON object.",
@@ -61,6 +65,16 @@
         }
       },
       {
+        "id": "multi_doc_synthesizer",
+        "type": "MultiDocSynthesizerAgent",
+        "config": {
+          "description": "Combines individual PDF summaries into a cross-document synthesis.",
+          "model_key": "multi_doc_synthesizer_model",
+          "system_message_key": "multi_doc_synthesizer_sm",
+          "temperature": 0.6
+        }
+      },
+      {
         "id": "short_term_memory_node",
         "type": "ShortTermMemoryAgent",
         "config": {
@@ -78,6 +92,16 @@
           "temperature": 0.7,
           "top_k": 3,
           "reasoning_effort": "high"
+        }
+      },
+      {
+        "id": "web_researcher",
+        "type": "WebResearcherAgent",
+        "config": {
+          "description": "Performs complementary web-style research based on the deep research synthesis.",
+          "model_key": "web_research_model",
+          "system_message_key": "web_researcher_sm",
+          "temperature": 0.6
         }
       },
       {
@@ -169,6 +193,13 @@
         }
       },
       {
+        "from": "pdf_summarizer_node",
+        "to": "multi_doc_synthesizer",
+        "data_mapping": {
+          "results": "all_pdf_summaries"
+        }
+      },
+      {
         "from": "initial_input_provider",
         "to": "deep_research_summarizer",
         "data_mapping": {
@@ -197,6 +228,13 @@
         }
       },
       {
+        "from": "deep_research_summarizer",
+        "to": "web_researcher",
+        "data_mapping": {
+          "deep_research_summary": "cross_document_understanding"
+        }
+      },
+      {
         "from": "short_term_memory_node",
         "to": "long_term_memory_node",
         "data_mapping": {
@@ -204,17 +242,24 @@
         }
       },
       {
-        "from": "long_term_memory_node",
+        "from": "multi_doc_synthesizer",
         "to": "knowledge_integrator",
         "data_mapping": {
-          "long_term_memory_path": "multi_doc_synthesis"
+          "multi_doc_synthesis_output": "multi_doc_synthesis"
         }
       },
       {
         "from": "deep_research_summarizer",
         "to": "knowledge_integrator",
         "data_mapping": {
-          "deep_research_summary": "web_research_summary"
+          "deep_research_summary": "deep_research_summary"
+        }
+      },
+      {
+        "from": "web_researcher",
+        "to": "knowledge_integrator",
+        "data_mapping": {
+          "web_summary": "web_research_summary"
         }
       },
       {

--- a/multi_agent_llm_system.py
+++ b/multi_agent_llm_system.py
@@ -300,9 +300,12 @@ class GraphOrchestrator:
                     )
                     data_mapping = edge_def.get("data_mapping", {})
                     for _, target_key in data_mapping.items():
+                        missing_msg = f"Input from '{from_node_id}' missing."
                         agent_inputs[target_key] = None
                         agent_inputs[f"{target_key}_error"] = True
-                        agent_inputs["error"] = f"Input from '{from_node_id}' missing."
+                        agent_inputs[f"{target_key}_error_message"] = missing_msg
+                        agent_inputs[f"{target_key}_source"] = from_node_id
+                        agent_inputs["error"] = missing_msg
                     continue
 
                 data_mapping = edge_def.get("data_mapping")
@@ -313,15 +316,20 @@ class GraphOrchestrator:
                     for src_key, target_key in data_mapping.items():
                         if src_key in source_outputs:
                             agent_inputs[target_key] = source_outputs[src_key]
+                            agent_inputs[f"{target_key}_source"] = from_node_id
                             if source_outputs.get("error"):
                                 agent_inputs[f"{target_key}_error"] = True
+                                agent_inputs[f"{target_key}_error_message"] = source_outputs.get("error")
                         else:
                             log_status(
                                 f"[GraphOrchestrator] INPUT_ERROR: Source key '{src_key}' not found in output of '{from_node_id}' for target '{node_id}'."
                             )
+                            missing_key_msg = f"Key '{src_key}' missing from '{from_node_id}'."
                             agent_inputs[target_key] = None
                             agent_inputs[f"{target_key}_error"] = True
-                            agent_inputs["error"] = f"Key '{src_key}' missing from '{from_node_id}'."
+                            agent_inputs[f"{target_key}_error_message"] = missing_key_msg
+                            agent_inputs[f"{target_key}_source"] = from_node_id
+                            agent_inputs["error"] = missing_key_msg
 
             # Special case for experimental data loader to get path from initial inputs if not connected by an edge
             if isinstance(current_agent, ExperimentalDataLoaderAgent) and "experimental_data_file_path" not in agent_inputs:

--- a/tests/test_agent_integration.py
+++ b/tests/test_agent_integration.py
@@ -68,6 +68,7 @@ class TestAgentIntegration(unittest.TestCase):
         knowledge_out = self.knowledge_agent.execute(
             {
                 "multi_doc_synthesis": multi_doc_out["multi_doc_synthesis_output"],
+                "deep_research_summary": "deep",
                 "web_research_summary": "web",
                 "experimental_data_summary": "data",
             }

--- a/tests/test_knowledge_integrator_agent.py
+++ b/tests/test_knowledge_integrator_agent.py
@@ -30,6 +30,7 @@ class TestKnowledgeIntegratorAgent(unittest.TestCase):
         """Agent integrates multiple sources into a knowledge brief."""
         inputs = {
             "multi_doc_synthesis": "docs",
+            "deep_research_summary": "deep",
             "web_research_summary": "web",
             "experimental_data_summary": "data",
         }
@@ -42,8 +43,13 @@ class TestKnowledgeIntegratorAgent(unittest.TestCase):
         """Agent handles upstream error flags without failing."""
         inputs = {
             "multi_doc_synthesis_error": True,
+            "deep_research_summary_error": True,
             "web_research_summary_error": True,
             "experimental_data_summary_error": True,
+            "multi_doc_synthesis_error_message": "fail docs",
+            "deep_research_summary_error_message": "fail deep",
+            "web_research_summary_error_message": "fail web",
+            "experimental_data_summary_error_message": "fail data",
             "error": "fail",
         }
         result = self.agent.execute(inputs)


### PR DESCRIPTION
## Summary
- propagate upstream source metadata and error messages when gathering agent inputs
- expand the workflow configuration with multi-document synthesis and web research nodes feeding the knowledge integrator
- enhance the knowledge integrator to ingest deep research summaries and other agent contributions, updating unit tests accordingly

## Testing
- pytest tests/test_knowledge_integrator_agent.py tests/test_agent_integration.py tests/test_config_schema.py

------
https://chatgpt.com/codex/tasks/task_e_68c9a433117083319335fb1defd2bcb1