### PR TITLE
Add fallback graph rendering using matplotlib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,5 @@ reportlab
 PyQt6
 pydantic
 graphviz
+matplotlib
+networkx


### PR DESCRIPTION
## Summary
- add a matplotlib/networkx based fallback so orchestrator graph images render even without graphviz binaries
- refactor visualization helpers to reuse label formatting and continue to emit Mermaid files as a final fallback
- include matplotlib and networkx in the Python requirements list

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca500fecdc8331b4d22681cb07c351