### PR TITLE
Handle optional user query input gracefully

### DIFF
--- a/agents/deep_research_summarizer_agent.py
+++ b/agents/deep_research_summarizer_agent.py
@@ -40,6 +40,20 @@ class DeepResearchSummarizerAgent(Agent):
         """
         log_status(f"[{self.agent_id}] INFO: Deep research summarizer agent is processing inputs: {inputs}")
 
+        if inputs.get("user_query_error"):
+            reason = inputs.get(
+                "user_query_error_message",
+                "User query was not provided by the initial inputs.",
+            )
+            log_status(
+                f"[{self.agent_id}] INFO: Skipping deep research summarization because {reason}"
+            )
+            return {
+                "deep_research_summary": "",
+                "skipped": True,
+                "skipped_reason": reason,
+            }
+
         user_query = inputs.get("user_query")
         if not user_query:
             log_status(f"[{self.agent_id}] ERROR: Input 'user_query' was not provided.")

--- a/tests/test_deep_research_summarizer_agent.py
+++ b/tests/test_deep_research_summarizer_agent.py
@@ -51,6 +51,19 @@ class TestDeepResearchSummarizerAgent(unittest.TestCase):
         self.assertIn("error", result)
         self.assertEqual(result["deep_research_summary"], "")
 
+    def test_user_query_error_flag_causes_skip_without_error(self):
+        """When upstream marks the query as missing, the agent reports a skip instead of an error."""
+        agent = self._make_agent()
+        result = agent.execute(
+            {
+                "user_query_error": True,
+                "user_query_error_message": "Optional input 'user_query' was not provided.",
+            }
+        )
+        self.assertEqual(result.get("deep_research_summary"), "")
+        self.assertNotIn("error", result)
+        self.assertTrue(result.get("skipped"))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- treat missing optional initial inputs like `user_query` as non-fatal in the orchestrator while still surfacing context
- teach the deep research summarizer to skip execution without error when the query is absent and add regression coverage
- add integration coverage ensuring the orchestrator runs cleanly when deep research is skipped

## Testing
- `pytest tests/test_deep_research_summarizer_agent.py tests/test_orchestrator.py`


------
https://chatgpt.com/codex/tasks/task_e_68d171e67ef0833199f773cfbebf669f