### PR TITLE
Add default workflow routes to predefined_routes.ini

### DIFF
--- a/predefined_routes.ini
+++ b/predefined_routes.ini
@@ -1,6 +1,10 @@
 [routes]
 # Define predefined routes here, e.g.:
 # route1 = start->middle->end
+integrated_analysis = initial_input_provider->pdf_loader_node->pdf_summarizer_node->multi_doc_synthesizer->short_term_memory_node->long_term_memory_node->deep_research_summarizer->web_researcher->experimental_data_loader->knowledge_integrator->hypothesis_generator->experiment_designer
+summaries_only = initial_input_provider->pdf_loader_node->pdf_summarizer_node->pdf_summary_writer_node
+memory_update = initial_input_provider->pdf_loader_node->pdf_summarizer_node->short_term_memory_node->long_term_memory_node
+deep_research_focus = initial_input_provider->pdf_loader_node->pdf_summarizer_node->short_term_memory_node->deep_research_summarizer->web_researcher
 
 [options]
 # Set to true to allow ``gui.py --install-deps`` to install packages automatically


### PR DESCRIPTION
## Summary
- populate the predefined routes configuration with the integrated analysis and supporting workflow routes used by the GUI so they are available by default

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d17c5c523c8331b29f0808069e0cf2