### PR TITLE
Fix fallback visualization output and update docs/tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ---
 
 # MACS: Multi-Agent LLM Research Assistant
-**MACS** (Multi-Agent Collaboration System) is a open-source modular Python-based platform for orchestrating advanced research workflows on collections of academic PDFs. It leverages multiple intelligent agents and LLMs to extract, summarize, and synthesize information from academic PDFs and experimental data, supporting literature reviews, hypothesis generation, and experiment planning.
+**MACS** (Multi-Agent Collaboration System) is an open-source modular Python-based platform for orchestrating advanced research workflows on collections of academic PDFs. It leverages multiple intelligent agents and LLMs to extract, summarize, and synthesize information from academic PDFs and experimental data, supporting literature reviews, hypothesis generation, and experiment planning.
 
 # Features
 - Automated Literature Review: Extracts and summarizes research articles from PDFs.

--- a/multi_agent_llm_system.py
+++ b/multi_agent_llm_system.py
@@ -363,7 +363,7 @@ class GraphOrchestrator:
         )
         if plt is not None and nx is not None:
             try:
-                self._visualize_with_networkx(
+                return self._visualize_with_networkx(
                     output_path, highlight_node_id, notify=False
                 )
             except Exception as exc:  # pylint: disable=broad-exception-caught


### PR DESCRIPTION
## Summary
- ensure the matplotlib/networkx fallback returns the generated PNG instead of always falling back to Mermaid output
- refresh the README introduction wording and agent development guide to match the current registration API
- expand the orchestrator visualization test to cover both the PNG fallback and Mermaid fallback paths

## Testing
- pytest tests/test_orchestrator.py

------
https://chatgpt.com/codex/tasks/task_e_68d2c31d9d548331bbcecf4651759e70